### PR TITLE
Fix submitOnEnter when multiple input elements are present

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -483,7 +483,7 @@ export default class Form extends Component {
     if (code === 13 && this.args.submitOnEnter) {
       let submitEvent = document.createEvent('Event');
       submitEvent.initEvent('submit', true, true);
-      event.target.dispatchEvent(submitEvent);
+      event.target.closest('form').dispatchEvent(submitEvent);
     }
   }
 

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -997,6 +997,21 @@ module('Integration | Component | bs-form', function (hooks) {
     assert.ok(submit.calledOnce, 'onSubmit action has been called');
   });
 
+  testRequiringFocus(
+    'Pressing enter on a form with multiple input elements and submitOnEnter submits the form',
+    async function (assert) {
+      let submit = sinon.spy();
+      this.actions.submit = submit;
+      await render(hbs`
+        <BsForm @onSubmit={{action "submit"}} @submitOnEnter={{true}} as |form|>
+          <form.element @property="input1" />
+          <form.element @property="input2" />
+        </BsForm>`);
+      await triggerKeyEvent('input', 'keypress', 13);
+      assert.ok(submit.calledOnce, 'onSubmit action has been called');
+    }
+  );
+
   test('prevents submission to be fired concurrently', async function (assert) {
     let deferredSubmitAction = defer();
     let submitActionHasBeenExecuted = false;


### PR DESCRIPTION
This PR resolves an issue where 'submitOnEnter' would not fire when more than one input element was present in the form.

For example

```
<BsForm
    @model={{hash field1='x' field2='y'}}
    @formLayout='horizontal'
    @onSubmit={{perform this.submit}}
    @submitOnEnter={{true}} as |bsForm|>
    <bsForm.element @property="field1" @label="field1" />
    <bsForm.element @property="field2" @label="field2" />
</BsForm>
```

Would not call 'this.submit' when enter was pressed on one of the input elements.

The original issue arose in ember-bootstrap 4.0.1.

This PR resolves the issue by directing the `submitEvent` to the form, rather than the triggering input element. This effectively restores the behavior in ember-bootstrap 4.0.0 and earlier.

Interestingly the test case I have added failed with both a single <form.element> and with two <form.element>s. After the fix  the test case passes with both one and two elements, so I have left it in place with two elements as this is what was manifesting the problem.

Please let me know if any changes are desired?