### PR TITLE
control programmatically if validation errors should be shown

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -347,13 +347,34 @@ export default class Form extends Component {
   validate(model, form) {} // eslint-disable-line no-unused-vars
 
   /**
-   * @property showAllValidations
+   * @property _showAllValidations
    * @type boolean
    * @default undefined
    * @private
    */
   @tracked
-  showAllValidations = undefined;
+  _showAllValidations = undefined;
+
+  get showAllValidations() {
+    return this.showValidations ?? this._showAllValidations;
+  }
+  set showAllValidations(showAllValidations) {
+    this._showAllValidations = showAllValidations;
+  }
+
+  /**
+   * Controls visibility of validation errors. If `null` (default) validation errors are shown after user
+   * interactions like form submission, focus out event of input fields etc. If `true` all validation errors are shown
+   * immediately independently of user interactions. If `false` validation errors are not shown in any case (but
+   * prevent form submission if form is invalid).
+   *
+   * @property showValidations
+   * @type Boolean|null
+   * @default null
+   * @public
+   */
+  @arg
+  showValidations = null;
 
   /**
    * Action is called before the form is validated (if possible) and submitted.

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -321,6 +321,97 @@ module('Integration | Component | bs-form', function (hooks) {
     assert.dom(`.${formFeedbackClass()}`).hasText('There is an error');
   });
 
+  test('Form with invalid validation shows validation errors immediately when @showValidations is true', async function (assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A(['There is an error']));
+
+    this.set('form', ensureSafeComponent(ValidatingForm, this));
+    this.set('formElement', ensureSafeComponent(ValidatingFormElement, this));
+
+    await render(
+      hbs`<this.form @elementComponent={{this.formElement}} @model={{this.model}} @validate={{false}} @showValidations={{true}} as |form|><form.element @errors={{this.errors}} /></this.form>`
+    );
+
+    assert
+      .dom(formFeedbackElement())
+      .hasClass(validationErrorClass(), 'validation errors are shown when @showValidations is true');
+    assert.dom(`.${formFeedbackClass()}`).hasText('There is an error');
+  });
+
+  test('Form with valid validation shows validation success immediately when @showValidations is true', async function (assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A([]));
+
+    this.set('form', ensureSafeComponent(ValidatingForm, this));
+    this.set('formElement', ensureSafeComponent(ValidatingFormElement, this));
+
+    await render(
+      hbs`<this.form @elementComponent={{this.formElement}} @model={{this.model}} @validate={{false}} @showValidations={{true}} as |form|><form.element @errors={{this.errors}} /></this.form>`
+    );
+
+    assert
+      .dom(formFeedbackElement())
+      .hasClass(validationSuccessClass(), 'validation success is shown when @showValidations is true');
+  });
+
+  test('Form with invalid validation does not show validation success or errors when @showValidations is false', async function (assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A(['There is an error']));
+
+    this.set('form', ensureSafeComponent(ValidatingForm, this));
+    this.set('formElement', ensureSafeComponent(ValidatingFormElement, this));
+
+    await render(
+      hbs`<this.form @elementComponent={{this.formElement}} @model={{this.model}} @validate={{false}} @showValidations={{false}} as |form|><form.element @errors={{this.errors}} /></this.form>`
+    );
+
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationErrorClass(), "validation errors aren't shown before user interaction");
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationSuccessClass(), "validation success isn't shown before user interaction");
+    await triggerEvent('form', 'submit');
+
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationErrorClass(), "validation errors aren't shown after user interaction");
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationSuccessClass(), "validation success isn't shown after user interaction");
+  });
+
+  test('Form with valid validation does not show validation success or errors when @showValidations is false', async function (assert) {
+    let model = {};
+    this.set('model', model);
+    this.set('errors', A([]));
+
+    this.set('form', ensureSafeComponent(ValidatingForm, this));
+    this.set('formElement', ensureSafeComponent(ValidatingFormElement, this));
+
+    await render(
+      hbs`<this.form @elementComponent={{this.formElement}} @model={{this.model}} @validate={{false}} @showValidations={{false}} as |form|><form.element @errors={{this.errors}} /></this.form>`
+    );
+
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationErrorClass(), "validation errors aren't shown before user interaction");
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationSuccessClass(), "validation success isn't shown before user interaction");
+    await triggerEvent('form', 'submit');
+
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationErrorClass(), "validation errors aren't shown after user interaction");
+    assert
+      .dom(formFeedbackElement())
+      .hasNoClass(validationSuccessClass(), "validation success isn't shown after user interaction");
+  });
+
   // skipping for now due to https://github.com/kaliber5/ember-bootstrap/issues/1682
   // @todo re-enable when this has been resolved
   skip('it does not catch errors thrown by synchronous @onSubmit action', async function (assert) {


### PR DESCRIPTION
Adds a public property `@showValidations` to `<BsForm>` to show/hide validations as proposed by @jelhan in https://github.com/ember-bootstrap/ember-bootstrap/issues/364#issuecomment-309417556

close #364