### PR TITLE
Fix CI for BS5

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@ember/test-helpers": "2.8.1",
     "@embroider/test-setup": "1.7.1",
     "babel-eslint": "10.1.0",
-    "bootstrap": "5.1.3",
+    "bootstrap": "5.2.1",
     "broccoli-asset-rev": "3.0.0",
     "chai": "4.3.6",
     "chai-things": "0.2.0",

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -9,6 +9,7 @@ import {
   tooltipArrowClass,
   tooltipPositionClass,
   visibilityClass,
+  versionDependant,
 } from '../../helpers/bootstrap';
 import { assertPositioning, setupForPositioning } from '../../helpers/contextual-help';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
@@ -390,7 +391,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should position tooltip arrow centered', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
-    let expectedArrowPosition = 94;
+    let expectedArrowPosition = versionDependant(94, 100);
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
       <div id="wrapper">
@@ -420,7 +421,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
     this.insertCSSRule('#target { width: 100px; padding: 0; border: none; }');
 
-    let expectedArrowPosition = 144;
+    let expectedArrowPosition = versionDependant(144, 156);
 
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>

--- a/tests/integration/components/bs-tooltip-test.js
+++ b/tests/integration/components/bs-tooltip-test.js
@@ -9,7 +9,7 @@ import {
   tooltipArrowClass,
   tooltipPositionClass,
   visibilityClass,
-  versionDependant,
+  versionDependent,
 } from '../../helpers/bootstrap';
 import { assertPositioning, setupForPositioning } from '../../helpers/contextual-help';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
@@ -391,7 +391,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should position tooltip arrow centered', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
-    let expectedArrowPosition = versionDependant(94, 100);
+    let expectedArrowPosition = versionDependent(94, 100);
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>
       <div id="wrapper">
@@ -421,7 +421,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
     this.insertCSSRule('#target { width: 100px; padding: 0; border: none; }');
 
-    let expectedArrowPosition = versionDependant(144, 156);
+    let expectedArrowPosition = versionDependent(144, 156);
 
     await render(hbs`
       <div id="ember-bootstrap-wormhole"></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3092,10 +3092,10 @@ boom@0.4.x:
   dependencies:
     hoek "0.9.x"
 
-bootstrap@5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
-  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
+bootstrap@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.1.tgz#45f97ff05cbe828bad807b014d8425f3aeb8ec3a"
+  integrity sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==
 
 bower-config@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Bootstrap 5.2 seems to have introduced some CSS changes to tooltips that make our tooltip positioning tests fail, as they are very coupled to CSS layout.