### PR TITLE
drop support for node 12 and 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
       - name: Lint
@@ -40,7 +40,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
         with:
@@ -88,7 +88,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
       - name: Install addon dependencies
         uses: bahmutov/npm-install@v1
       - name: Install docs dependencies

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ember Bootstrap works and is fully [tested](https://github.com/kaliber5/ember-bo
 * Ember CLI 3.24+
 * Bootstrap 4 and 5
 * all modern evergreen browsers (Chrome, Firefox, Safari, Edge)
-* node.js 12+
+* node.js 14+
 * FastBoot 1.0+
 * Embroider: we strive (and test) for maximum compatibility with Embroider, including the most aggressive setting 
 (`staticComponents`) for tree shaking and code splitting. However as Embroider itself is still considered beta software, 

--- a/docs/package.json
+++ b/docs/package.json
@@ -72,7 +72,7 @@
     "webpack": "5.74.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "ember-source": ">=3.24"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This drops support for node 12 and 17, which both reached end of life. This unblocks supporting ember-style-modifier v1 and v2. See #1826 for context.