### PR TITLE
drop support for Ember 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
         allow-failure:
           - false
         scenario:
-          - ember-lts-3.24
           - ember-lts-3.28
           - ember-release
           - ember-beta

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To switch Bootstrap version or preprocessor, see the [setup documentation](http:
 
 Ember Bootstrap works and is fully [tested](https://github.com/kaliber5/ember-bootstrap/actions?query=workflow%3ACI+branch%3Amaster) with
 
-* Ember.js 3.24+ (including all optional features)
-* Ember CLI 3.24+
+* Ember.js 3.28+ (including all optional features)
+* Ember CLI 3.28+
 * Bootstrap 4 and 5
 * all modern evergreen browsers (Chrome, Firefox, Safari, Edge)
 * node.js 12+

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,15 +9,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.24',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.24.3',
-            bootstrap: bootstrapVersion,
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.28',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "webpack": "5.74.0"
   },
   "peerDependencies": {
-    "ember-source": ">=3.24"
+    "ember-source": ">=3.28"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
I feel we should drop support for Ember 3.24 in next major release. It is likely that polyfills etc support Ember 3.28 than supporting Ember 3.24 going forward. This will give us more flexibility. Applications can continue using Ember Bootstrap even if not being ready for Ember v4 upgrade. They just need to use latest minor release of the 3.x series.