### PR TITLE
fix HTML markup for <BsAccordion> per Bootstrap docs

### DIFF
--- a/addon/components/bs-accordion.hbs
+++ b/addon/components/bs-accordion.hbs
@@ -1,6 +1,5 @@
 <div
   class="accordion"
-  role="tablist"
   ...attributes
 >
   {{yield

--- a/addon/components/bs-accordion/item.hbs
+++ b/addon/components/bs-accordion/item.hbs
@@ -1,7 +1,9 @@
 {{#let
   (component (ensure-safe-component (bs-default @titleComponent (component "bs-accordion/item/title"))) collapsed=this.collapsed disabled=@disabled onClick=(fn (bs-default @onClick (bs-noop)) this.value))
   (component (ensure-safe-component (bs-default @bodyComponent (component "bs-accordion/item/body"))) collapsed=this.collapsed)
-as |Title Body|
+  (unique-id)
+  (unique-id)
+as |Title Body titleId collapsableId|
 }}
   <div
     class="{{if @disabled "disabled"}} {{this.typeClass}} {{if (macroCondition (macroGetOwnConfig "isBS4")) "card"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-item"}}"
@@ -11,14 +13,15 @@ as |Title Body|
       {{yield
         (hash
           title=Title
-          body=Body        )
+          body=Body
+        )
       }}
     {{else}}
-      <Title>
+      <Title id={{titleId}} @controls={{collapsableId}}>
         {{@title}}
       </Title>
-      <Body>
-      {{yield}}
+      <Body @collapsableId={{collapsableId}} @describedby={{titleId}}>
+        {{yield}}
       </Body>
     {{/if}}
   </div>

--- a/addon/components/bs-accordion/item/body.hbs
+++ b/addon/components/bs-accordion/item/body.hbs
@@ -1,4 +1,4 @@
-<BsCollapse @collapsed={{@collapsed}} role="tabpanel">
+<BsCollapse @collapsed={{@collapsed}} class="accordion-collapse" id={{@collapsableId}} aria-describedby={{@describedby}}>
   <div class="{{if (macroCondition (macroGetOwnConfig "isBS4")) "card-body"}} {{if (macroCondition (macroGetOwnConfig "isBS5")) "accordion-body"}}">
     {{yield}}
   </div>

--- a/addon/components/bs-accordion/item/title.hbs
+++ b/addon/components/bs-accordion/item/title.hbs
@@ -19,9 +19,11 @@
 {{else}}
   <div
     class="card-header"
-    ...attributes
   >
-    <h2 class="mb-0">
+    <h2
+      class="mb-0"
+      ...attributes
+    >
       <button
         class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}"
         type="button"

--- a/addon/components/bs-accordion/item/title.hbs
+++ b/addon/components/bs-accordion/item/title.hbs
@@ -3,13 +3,14 @@
 {{#if (macroCondition (macroGetOwnConfig "isBS5"))}}
   <h2
     class="accordion-header"
-    role="tab"
     ...attributes
   >
     <button
       class="accordion-button {{if @disabled "disabled"}} {{if @collapsed "collapsed"}}"
       type="button"
       disabled={{@disabled}}
+      aria-controls={{@controls}}
+      aria-expanded={{if @collapsed "false" "true"}}
       {{on "click" this.handleClick}}
     >
       {{yield}}
@@ -18,12 +19,17 @@
 {{else}}
   <div
     class="card-header"
-    role="tab"
     ...attributes
-    {{on "click" this.handleClick}}
   >
     <h5 class="mb-0">
-      <button class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}" type="button" disabled={{@disabled}}>
+      <button
+        class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}"
+        type="button"
+        disabled={{@disabled}}
+        aria-controls={{@controls}}
+        aria-expanded={{if @collapsed "false" "true"}}
+        {{on "click" this.handleClick}}
+      >
         {{yield}}
       </button>
     </h5>

--- a/addon/components/bs-accordion/item/title.hbs
+++ b/addon/components/bs-accordion/item/title.hbs
@@ -21,7 +21,7 @@
     class="card-header"
     ...attributes
   >
-    <h5 class="mb-0">
+    <h2 class="mb-0">
       <button
         class="btn btn-link {{if @disabled "disabled"}} {{if @collapsed "collapsed" "expanded"}}"
         type="button"
@@ -32,6 +32,6 @@
       >
         {{yield}}
       </button>
-    </h5>
+    </h2>
   </div>
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "ember-source-channel-url": "3.0.0",
     "ember-template-lint": "3.16.0",
     "ember-try": "2.0.0",
+    "ember-unique-id-helper-polyfill": "^1.2.2",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-ember": "10.6.1",

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -97,7 +97,7 @@ export function accordionClassFor(type) {
 }
 
 export function accordionTitleSelector() {
-  return versionDependent('h5', 'h2.accordion-header');
+  return versionDependent('.card-header h2', 'h2.accordion-header');
 }
 
 export function accordionItemHeadClass() {
@@ -105,7 +105,7 @@ export function accordionItemHeadClass() {
 }
 
 export function accordionItemClickableSelector() {
-  return versionDependent('h5 button', '.accordion-header button');
+  return versionDependent('.card-header h2 button', '.accordion-header button');
 }
 
 export function dropdownVisibilityElementSelector() {

--- a/tests/integration/components/bs-accordion-test.js
+++ b/tests/integration/components/bs-accordion-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render, settled } from '@ember/test-helpers';
+import { click, find, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {
   accordionClass,
@@ -26,14 +26,32 @@ module('Integration | Component | bs-accordion', function (hooks) {
   test('accordion has correct default markup', async function (assert) {
     await render(hbs`
       <BsAccordion as |acc|>
-        <acc.item @value={{1}} @title="TITLE1">CONTENT1</acc.item>
+        <acc.item @value={{1}} @title="TITLE1" data-test-item="1">CONTENT1</acc.item>
         <acc.item @value={{2}} @title="TITLE2">CONTENT2</acc.item>
       </BsAccordion>
     `);
     assert.dom(`.${accordionClass()}`).exists({ count: 1 }, 'accordion has correct class');
     assert
+      .dom(`.${accordionClass()} .accordion-collapse`)
+      .exists({ count: 2 }, 'collapsable area of accordion has correct class');
+    assert
       .dom(`.${accordionClass()} .${accordionItemClass()}`)
       .exists({ count: 2 }, 'accordion item has correct class');
+    assert.dom('[data-test-item="1"] h2').hasText('TITLE1', 'renders title');
+    assert
+      .dom('[data-test-item="1"] .accordion-collapse')
+      .hasAria(
+        'describedby',
+        find('[data-test-item="1"] h2').id,
+        'aria: accordion body is described by accordion title'
+      );
+    assert
+      .dom('[data-test-item="1"] h2 button')
+      .hasAria(
+        'controls',
+        find('[data-test-item="1"] .accordion-collapse').id,
+        'aria: accordion title controls collapsable part'
+      );
   });
 
   test('accordion with preselected item has this item expanded', async function (assert) {
@@ -46,8 +64,9 @@ module('Integration | Component | bs-accordion', function (hooks) {
     `);
 
     assert
-      .dom(`.${accordionItemClass()}:first-child .${accordionItemHeadClass()}`)
-      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`);
+      .dom(`.${accordionItemClass()}:first-child ${accordionItemClickableSelector()}`)
+      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`)
+      .hasAria('expanded', 'true', 'aria: is expanded');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass('collapse', 'tabpanel has collapse class');
     assert
       .dom(`.${accordionItemClass()}:first-child .collapse`)
@@ -67,8 +86,9 @@ module('Integration | Component | bs-accordion', function (hooks) {
     // wait for transitions to complete
     await settled();
     assert
-      .dom(`.${accordionItemClass()}:last-child .${accordionItemHeadClass()}`)
-      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`);
+      .dom(`.${accordionItemClass()}:last-child ${accordionItemClickableSelector()}`)
+      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`)
+      .hasAria('expanded', 'true', 'aria: is expanded');
     assert.dom(`.${accordionItemClass()}:last-child .collapse`).hasClass('collapse', 'tabpanel has collapse class');
     assert.dom(`.${accordionItemClass()}:last-child .collapse`).hasClass(visibilityClass(), 'tabpanel is visible');
   });
@@ -83,8 +103,9 @@ module('Integration | Component | bs-accordion', function (hooks) {
     await click(`.${accordionItemClass()}:first-child ${accordionItemClickableSelector()}`);
 
     assert
-      .dom(`.${accordionItemClass()}:first-child .${accordionItemHeadClass()}`)
-      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`);
+      .dom(`.${accordionItemClass()}:first-child ${accordionItemClickableSelector()}`)
+      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`)
+      .hasAria('expanded', 'true', 'aria: is expanded');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass('collapse', 'tabpanel has collapse class');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass(visibilityClass(), 'tabpanel is visible');
   });
@@ -99,7 +120,8 @@ module('Integration | Component | bs-accordion', function (hooks) {
 
     assert
       .dom(`.${accordionItemClass()}:first-child ${accordionItemClickableSelector()}`)
-      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`);
+      .hasNoClass('collapsed', `${accordionItemHeadClass()} has not collapsed class`)
+      .hasAria('expanded', 'true', 'aria: is expanded');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass('collapse', 'tabpanel has collapse class');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass(visibilityClass(), 'tabpanel is visible');
 
@@ -107,7 +129,8 @@ module('Integration | Component | bs-accordion', function (hooks) {
 
     assert
       .dom(`.${accordionItemClass()}:first-child ${accordionItemClickableSelector()}`)
-      .hasClass('collapsed', `${accordionItemHeadClass()} has collapsed class`);
+      .hasClass('collapsed', `${accordionItemHeadClass()} has collapsed class`)
+      .hasAria('expanded', 'false', 'aria: is expanded');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasClass('collapse', 'tabpanel has collapse class');
     assert.dom(`.${accordionItemClass()}:first-child .collapse`).hasNoClass(visibilityClass(), 'tabpanel is hidden');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,7 +5300,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -6094,6 +6094,15 @@ ember-try@2.0.0:
     resolve "^1.20.0"
     rimraf "^3.0.2"
     walk-sync "^2.2.0"
+
+ember-unique-id-helper-polyfill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-1.2.2.tgz#64ab71b378cca117aa7d56d4275f47ff3b830b6d"
+  integrity sha512-gjcwTBkCDUA0iYFS7aArfJub+eos/itxEsC399JUbdKNIBJLesB/1OHnmxLLwExZHp7gyHuiDFOPcknafhFm3g==
+  dependencies:
+    broccoli-funnel "^3.0.8"
+    ember-cli-babel "^7.26.10"
+    ember-cli-version-checker "^5.1.2"
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This updates the markup for `<BsAccordion>` accordingly to Bootstrap documentation:

- for Bootstrap v5: https://getbootstrap.com/docs/5.3/components/accordion/
- for Bootstrap v4: https://getbootstrap.com/docs/4.6/components/collapse/#accordion-example

Neither of them are using `role="tab"`, which is causing the test to fail on latest `master` branch. See #1843 for context.

For Bootstrap v4 there were more mismatches between the markup rendered by Ember Bootstrap and the markup provided in Bootstrap docs. The fixes for those mismatches are breaking changes:

1. The title is rendered as a `h2`. Before it was a `h5`.
2. Only the title is clickable to expand / collapse the content of an accordion item. Before it was the entire header.
3. Attributes set on `<Accordion::Item::Title>` are applied to `h2`. Before they were applied to `.card-header`.

Closes #1843 