### PR TITLE
do not fail on @ember/string deprecation

### DIFF
--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -9,6 +9,8 @@ let expectedDeprecations = new Set();
 const ignoredDeprecations = [
   // @todo remove when https://github.com/alexlafroscia/ember-popper-modifier/issues/452 is fixed
   /ember-modifier/,
+  // @todo remove as part of https://github.com/ember-bootstrap/ember-bootstrap/pull/1845
+  /@ember\/string/,
 ];
 
 export default function setupNoDeprecations({ beforeEach, afterEach }) {


### PR DESCRIPTION
Fixing the `@ember/string` deprecation does not seem to be as easy as hoped. Let's ignore it for now to have a green CI pipeline again and easy development. Will remove it again as part of #1845.