### PR TITLE
drop dependency on @ember/string

### DIFF
--- a/addon/components/bs-collapse.js
+++ b/addon/components/bs-collapse.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { isNone } from '@ember/utils';
 import { next } from '@ember/runloop';
-import { camelize } from '@ember/string';
 import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 import { ref } from 'ember-ref-bucket';
@@ -223,7 +222,9 @@ export default class Collapse extends Component {
 
     let collapseElement = this._element;
     let prefix = action === 'show' ? 'scroll' : 'offset';
-    let measureProperty = camelize(`${prefix}-${this.collapseDimension}`);
+    let measureProperty = `${prefix}${this.collapseDimension
+      .substring(0, 1)
+      .toUpperCase()}${this.collapseDimension.substring(1)}`;
     return collapseElement[measureProperty];
   }
 

--- a/tests/helpers/setup-no-deprecations.js
+++ b/tests/helpers/setup-no-deprecations.js
@@ -9,7 +9,8 @@ let expectedDeprecations = new Set();
 const ignoredDeprecations = [
   // @todo remove when https://github.com/alexlafroscia/ember-popper-modifier/issues/452 is fixed
   /ember-modifier/,
-  // @todo remove as part of https://github.com/ember-bootstrap/ember-bootstrap/pull/1845
+  // @todo remove as soon as @ember/string deprecation has been addressed in ember-style-modifier
+  // see https://github.com/jelhan/ember-style-modifier/pull/139
   /@ember\/string/,
 ];
 


### PR DESCRIPTION
This drops the dependency on `@ember/string`. This fixes the `@ember/string` deprecation for Ember Bootstrap itself. But it needs to be fixed in ember-style-modifier as well before we can throw on that deprecation again.

Thanks a lot @simonihmig for the hint in https://github.com/ember-bootstrap/ember-bootstrap/pull/1845#issuecomment-1383230945.

Closes #1845 