### PR TITLE
ignore docs/build generated by docs build in ESLint

### DIFF
--- a/docs/.eslintignore
+++ b/docs/.eslintignore
@@ -5,6 +5,7 @@
 /yuidoc-theme
 
 # compiled output
+/build/
 /dist/
 /tmp/
 


### PR DESCRIPTION
The `docs/build` folder is generated by `yarn docs:build` script. It should be ignored when linting the docs app.