### PR TITLE
build docs app as part of every CI run to catch issues early

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,15 @@ name: Publish docs
 on:
   workflow_dispatch:
   release:
-    types: [published,edited]
+    types:
+      - published
+      - edited
+  workflow_run:
+    workflows:
+      - CI
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
@@ -23,7 +28,20 @@ jobs:
           working-directory: docs
       - name: Build docs
         run: yarn run docs:build
+      - name: Upload docs build
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs-build
+          path: docs/build
 
+  deploy:
+    if: github.event.release
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Download docs build
+        uses: actions/download-artifact@v3
+        with:
+          name: docs-build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
We have seen docs build failing to often in the past _after_ a release. We haven't run the build at all before releasing. This caused us catching issues very late. Recent example for it is #1855. An incident with a longer time to resolve was #1387. I feel we should catch this issues early. Also to ease dependency upgrades.

I hoped that we reduce the risk of broken docs app by running linting and tests for it in CI. I added this in #1850. But there are many steps only done for a production build. So the risk of failing docs deployment is still high. As it has been proven by #1855.

This increases resource consumption of our CI pipeline. But I feel that trade-off is good for now.

I hope I haven't messed up with GitHub Action workflow. Not very experienced with GitHub Actions to be honest.