### PR TITLE
fix: correct dropdown direction class for BS5

### DIFF
--- a/addon/components/bs-dropdown.js
+++ b/addon/components/bs-dropdown.js
@@ -3,6 +3,7 @@ import { action, computed } from '@ember/object';
 import Component from '@ember/component';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import { assert } from '@ember/debug';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
 const ESCAPE_KEYCODE = 27; // KeyboardEvent.which value for Escape (Esc) key
@@ -238,10 +239,18 @@ export default class Dropdown extends Component {
    */
   @computed('direction', 'hasButton', 'toggleElement.classList')
   get containerClass() {
+    let dropDirectionClass = `drop${this.direction}`;
+    if (macroCondition(getOwnConfig().isBS5)) {
+      if (this.direction === 'left') {
+        dropDirectionClass = 'dropstart';
+      } else if (this.direction === 'right') {
+        dropDirectionClass = 'dropend';
+      }
+    }
     if (this.hasButton && !this.toggleElement.classList.contains('btn-block')) {
-      return this.direction !== 'down' ? `btn-group drop${this.direction}` : 'btn-group';
+      return this.direction !== 'down' ? `btn-group ${dropDirectionClass}` : 'btn-group';
     } else {
-      return `drop${this.direction}`;
+      return dropDirectionClass;
     }
   }
 

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -1,7 +1,7 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, focus, render, triggerKeyEvent } from '@ember/test-helpers';
-import { dropdownVisibilityElementSelector, isHidden, isVisible, openClass, test } from '../../helpers/bootstrap';
+import { dropdownVisibilityElementSelector, isHidden, isVisible, openClass, test, versionDependent } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -31,13 +31,15 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   test('dropdown container supports dropright style', async function (assert) {
     await render(hbs`<BsDropdown @direction="right">Test</BsDropdown>`);
 
-    assert.dom('.dropright').exists('has dropright class');
+    let droprightClass = versionDependent('.dropright', '.dropend');
+    assert.dom(droprightClass).exists('has dropright class');
   });
 
   test('dropdown container supports dropleft style', async function (assert) {
     await render(hbs`<BsDropdown @direction="left">Test</BsDropdown>`);
 
-    assert.dom('.dropleft').exists('has dropleft class');
+    let dropleftClass = versionDependent('.dropleft', '.dropstart');
+    assert.dom(dropleftClass).exists('has dropleft class');
   });
 
   test('dropdown container with dropdown button has btn-group class', async function (assert) {

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -1,7 +1,14 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, focus, render, triggerKeyEvent } from '@ember/test-helpers';
-import { dropdownVisibilityElementSelector, isHidden, isVisible, openClass, test, versionDependent } from '../../helpers/bootstrap';
+import {
+  dropdownVisibilityElementSelector,
+  isHidden,
+  isVisible,
+  openClass,
+  test,
+  versionDependent,
+} from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';


### PR DESCRIPTION
Short-term fix for #1863, applying the correct Bootstrap 5 classes for dropdowns with direction left or right.