### PR TITLE
WIP: drop RSVP dependency 

### DIFF
--- a/addon/components/bs-carousel.js
+++ b/addon/components/bs-carousel.js
@@ -7,7 +7,6 @@ import Component from '@ember/component';
 import ComponentParent from 'ember-bootstrap/mixins/component-parent';
 import { schedule, scheduleOnce } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
-import RSVP from 'rsvp';
 import defaultValue from 'ember-bootstrap/utils/default-decorator';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 
@@ -481,7 +480,7 @@ export default class Carousel extends Component.extend(ComponentParent) {
     this.set('presentationState', 'didTransition');
     // Must change current index after execution of 'presentationStateObserver' method
     // from child components.
-    yield new RSVP.Promise((resolve) => {
+    yield new Promise((resolve) => {
       schedule('afterRender', this, function () {
         this.set('currentIndex', this.followingIndex);
         resolve();

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -3,7 +3,6 @@ import { action, set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isPresent } from '@ember/utils';
 import { next } from '@ember/runloop';
-import RSVP from 'rsvp';
 import { getOwnConfig, macroCondition } from '@embroider/macros';
 import deprecateSubclassing from 'ember-bootstrap/utils/deprecate-subclassing';
 import arg from '../utils/decorators/arg';
@@ -419,7 +418,7 @@ export default class Form extends Component {
     }
 
     if (this.preventConcurrency && this.isSubmitting) {
-      return RSVP.resolve();
+      return Promise.resolve();
     }
 
     let model = this.model;
@@ -428,7 +427,7 @@ export default class Form extends Component {
 
     this.args.onBefore?.(model);
 
-    return RSVP.resolve()
+    return Promise.resolve()
       .then(() => {
         return this.hasValidator ? this.validate(model, this._element) : null;
       })
@@ -438,7 +437,7 @@ export default class Form extends Component {
             this.showAllValidations = false;
           }
 
-          return RSVP.resolve()
+          return Promise.resolve()
             .then(() => {
               return this.args.onSubmit?.(model, record);
             })
@@ -472,7 +471,7 @@ export default class Form extends Component {
             });
         },
         (error) => {
-          return RSVP.resolve()
+          return Promise.resolve()
             .then(() => {
               return this.args.onInvalid?.(model, error);
             })

--- a/addon/utils/transition-end.js
+++ b/addon/utils/transition-end.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { cancel, later } from '@ember/runloop';
-import { Promise, reject } from 'rsvp';
 
 let _skipTransition;
 
@@ -14,7 +13,7 @@ function _isSkipped() {
 
 export default function waitForTransitionEnd(node, duration = 0) {
   if (!node) {
-    return reject();
+    return Promise.reject();
   }
   let backup;
 

--- a/blueprints/ember-bootstrap/index.js
+++ b/blueprints/ember-bootstrap/index.js
@@ -1,10 +1,9 @@
 /* eslint-env node */
 'use strict';
 
-const rsvp = require('rsvp');
 const fs = require('fs-extra');
 const path = require('path');
-const writeFile = rsvp.denodeify(fs.writeFile);
+const fsPromises = require('fs/promises');
 const chalk = require('chalk');
 const BuildConfigEditor = require('ember-cli-build-config-editor');
 const SilentError = require('silent-error');
@@ -81,7 +80,7 @@ module.exports = {
     }
     promises.push(this.addPackageToProject('bootstrap', bootstrapVersion === 5 ? bs5Version : bs4Version));
 
-    return rsvp.all(promises);
+    return Promise.all(promises);
   },
 
   adjustPreprocessorDependencies() {
@@ -97,7 +96,7 @@ module.exports = {
       promises.push(this.addAddonToProject('ember-cli-sass'));
     }
 
-    return rsvp.all(promises);
+    return Promise.all(promises);
   },
 
   addPreprocessorStyleImport() {
@@ -121,7 +120,7 @@ module.exports = {
       return this.insertIntoFile(file, importStatement, {});
     } else {
       this.ui.writeLine(chalk.green(`Created ${file}`));
-      return writeFile(file, importStatement);
+      return fsPromises.writeFile(file, importStatement);
     }
   },
 

--- a/docs/app/controllers/demo/button.js
+++ b/docs/app/controllers/demo/button.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import RSVP from 'rsvp';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
 
@@ -11,7 +10,7 @@ export default class ButtonController extends Controller {
 
   @action
   download() {
-    return new RSVP.Promise(function (resolve) {
+    return new Promise(function (resolve) {
       later(resolve, 3000);
     });
   }

--- a/docs/app/controllers/demo/spinner.js
+++ b/docs/app/controllers/demo/spinner.js
@@ -1,12 +1,11 @@
 import Controller from '@ember/controller';
-import RSVP from 'rsvp';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
 
 export default class ButtonController extends Controller {
   @action
   download() {
-    return new RSVP.Promise(function (resolve) {
+    return new Promise(function (resolve) {
       later(resolve, 3000);
     });
   }

--- a/node-tests/blueprints/ember-bootstrap-test.js
+++ b/node-tests/blueprints/ember-bootstrap-test.js
@@ -16,7 +16,6 @@ const chai = require('ember-cli-blueprint-test-helpers/chai');
 const file = chai.file;
 const chaiThings = require('chai-things');
 const expect = chai.expect;
-const Promise = require('rsvp');
 
 const scenarios = require('./dependencyScenarios');
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "findup-sync": "^5.0.0",
     "fs-extra": "^10.0.0",
     "resolve": "^1.18.1",
-    "rsvp": "^4.0.1",
     "silent-error": "^1.0.1",
     "tracked-toolbox": "^1.2.3"
   },
@@ -187,5 +186,9 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "volta": {
+    "node": "14.21.3",
+    "yarn": "1.22.19"
   }
 }

--- a/tests/helpers/bootstrap.js
+++ b/tests/helpers/bootstrap.js
@@ -1,6 +1,5 @@
 import config from 'dummy/config/environment';
 import { skip, test } from 'qunit';
-import { Promise } from 'rsvp';
 
 const currentBootstrapVersion = parseInt(config.bootstrapVersion);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12855,7 +12855,7 @@ rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
-rsvp@^4.0.1, rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
+rsvp@^4.7.0, rsvp@^4.8.1, rsvp@^4.8.3, rsvp@^4.8.4, rsvp@^4.8.5:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==


### PR DESCRIPTION
This stems from an issue originally reported here: https://github.com/ef4/ember-auto-import/issues/564
Which was caused by this new feature to auto-import: https://github.com/ef4/ember-auto-import/pull/553
Which was intended to solve: https://github.com/ef4/ember-auto-import/issues/504
Which then had the default reverted here: https://github.com/ef4/ember-auto-import/pull/568
But an attempt to add more details around the hack is here: https://github.com/ef4/ember-auto-import/pull/566 (but this revealed just how important really solving the issue is, rather than continuing to work with the earlyBootSet)

Ultimately, RSVP isn't needed for anything anymore, so I figured I'd have a stab at just removing it for the time being