### PR TITLE
migrate husky configuration to v8

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn run lint-staged

--- a/package.json
+++ b/package.json
@@ -35,12 +35,8 @@
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
-    "test:ember-compatibility": "ember try:each"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
+    "test:ember-compatibility": "ember try:each",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix"


### PR DESCRIPTION
Husky was broken by #1794. Configuration needs to be migrated to be compatible with Husky v8.

Migration was done following the recommended steps here: https://typicode.github.io/husky/#/?id=husky-4-to-8-cli

1. Run [husky-4-to-8](https://github.com/typicode/husky-4-to-8#husky-4-to-8) migration script
2. Adjust created file to use local `lint-staged`  binary

Closes #1892 