### PR TITLE
remove ember-export-application-global dev dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -46,7 +46,6 @@
     "ember-cli-terser": "4.0.2",
     "ember-code-snippet": "3.0.0",
     "ember-cp-validations": "5.0.0",
-    "ember-export-application-global": "2.0.1",
     "ember-fetch": "8.1.2",
     "ember-load-initializers": "2.1.2",
     "ember-maybe-import-regenerator": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "ember-cli-yuidoc": "0.9.1",
     "ember-compatibility-helpers": "1.2.6",
     "ember-disable-prototype-extensions": "1.1.3",
-    "ember-export-application-global": "2.0.1",
     "ember-load-initializers": "2.1.2",
     "ember-page-title": "7.0.0",
     "ember-qunit": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5549,11 +5549,6 @@ ember-element-helper@^0.6.0:
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.0.1"
 
-ember-export-application-global@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
-  integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
-
 ember-focus-trap@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-focus-trap/-/ember-focus-trap-1.0.1.tgz#a99565f6ce55d500b92a0965e79e3ad04219f157"


### PR DESCRIPTION
`ember-export-application-global` is deprecated. It has been removed from addon and app blueprints. It is not compatible with Ember 5 and breaks canary tests therefore.

This only addresses one of the issues with Ember 5. Canary build is still failing due to issues with FastBoot.