### PR TITLE
Disable fastboot tests for ember canary

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -69,6 +69,9 @@ module.exports = async function () {
         },
         env: {
           // FAIL_ON_DEPRECATION: true,
+
+          // TODO: Enable again when FastBoot is ready for Ember 5
+          // https://github.com/ember-fastboot/ember-cli-fastboot/pull/905
           FASTBOOT_DISABLED: true,
         },
       },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -69,6 +69,7 @@ module.exports = async function () {
         },
         env: {
           // FAIL_ON_DEPRECATION: true,
+          FASTBOOT_DISABLED: true,
         },
       },
       {


### PR DESCRIPTION
FastBoot is not ready yet for Ember 5. Due not not addressed [implicit injections deprecation](https://deprecations.emberjs.com/v4.x#toc_implicit-injections) it is failing with Ember 5 and breaking canary scenario therefore. Disabling FastBoot tests for canary scenario as a workaround until it is fixed upstream.

We may need to do the same soonish for `ember-beta` scenario if it is not fixed in FastBoot before.