### PR TITLE
WIP: assert against HTML encoded character as rendered by template

### DIFF
--- a/tests/integration/components/bs-modal/header-test.js
+++ b/tests/integration/components/bs-modal/header-test.js
@@ -55,7 +55,7 @@ module('Integration | Component | bs-modal/header', function (hooks) {
   test('close button has expected content', async function (assert) {
     await render(hbs`<BsModal::Header @title="Header" />`);
 
-    assert.dom(`.modal-header button.${closeButtonClass()}`).hasText(versionDependent('×', ''));
+    assert.dom(`.modal-header button.${closeButtonClass()}`).hasText(versionDependent('&ntimes;', ''));
   });
 
   test('close button can be removed', async function (assert) {


### PR DESCRIPTION
Asserting against non-encoded character breaks `@embroider/test-setup` v2 upgrade in #1857.