### PR TITLE
remove buttonType argument of <BsButton>

### DIFF
--- a/addon/components/bs-button.hbs
+++ b/addon/components/bs-button.hbs
@@ -1,6 +1,6 @@
 <button
   disabled={{this.__disabled}}
-  type={{this.buttonType}}
+  type={{if @attrTypePrivateWorkaround @attrTypePrivateWorkaround "button"}}
   class="btn {{if @active "active"}} {{if (macroCondition (macroGetOwnConfig "isNotBS5")) (if this.block "btn-block")}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default="secondary" outline=@outline}}"
   ...attributes
   {{on "click" this.handleClick}}

--- a/addon/components/bs-button.js
+++ b/addon/components/bs-button.js
@@ -142,7 +142,6 @@ export default class Button extends Component {
    * @default null
    * @private
    */
-
   get __disabled() {
     if (this.args._disabled !== undefined) {
       return this.args._disabled;
@@ -150,17 +149,6 @@ export default class Button extends Component {
 
     return this.isPending && this.args.preventConcurrency !== false;
   }
-
-  /**
-   * Set the type of the button, either 'button' or 'submit'
-   *
-   * @property buttonType
-   * @type String
-   * @default 'button'
-   * @deprecated
-   * @public
-   */
-  @arg buttonType = 'button';
 
   /**
    * Set the 'active' class to apply active/pressed CSS styling

--- a/addon/components/bs-form.hbs
+++ b/addon/components/bs-form.hbs
@@ -26,10 +26,10 @@
       resetSubmissionState=this.resetSubmissionState
       submit=this.doSubmit
       submitButton=(component (ensure-safe-component (bs-default @submitButtonComponent (component "bs-button")))
-        buttonType="submit"
         type="primary"
         state=this.submitButtonState
         _disabled=this.isSubmitting
+        attrTypePrivateWorkaround="submit"
       )
     )
   }}

--- a/tests/integration/components/bs-button-test.js
+++ b/tests/integration/components/bs-button-test.js
@@ -72,13 +72,6 @@ module('Integration | Component | bs-button', function (hooks) {
     assert.equal(this.element.querySelector('button').type, 'button');
   });
 
-  test('buttonType property allows changing button type', async function (assert) {
-    await render(hbs`<BsButton @buttonType="submit" />`);
-
-    assert.dom('button').hasAttribute('type', 'submit');
-    // assert.deprecationsInclude('Argument buttonType of <BsButton> component is deprecated.');
-  });
-
   test('button with icon property shows icon', async function (assert) {
     await render(hbs`<BsButton @icon="fas fa-check" />`);
 

--- a/tests/integration/components/bs-form-test.js
+++ b/tests/integration/components/bs-form-test.js
@@ -130,7 +130,7 @@ module('Integration | Component | bs-form', function (hooks) {
   test('Clicking a submit button submits the form', async function (assert) {
     let submit = sinon.spy();
     this.actions.submit = submit;
-    await render(hbs`<BsForm @onSubmit={{action "submit"}}><BsButton @buttonType="submit">Submit</BsButton></BsForm>`);
+    await render(hbs`<BsForm @onSubmit={{action "submit"}}><button type="submit">Submit</button></BsForm>`);
 
     await click('button');
     assert.ok(submit.calledOnce, 'onSubmit action has been called');


### PR DESCRIPTION
`buttonType` argument of `<BsButton>` has been deprecated long ago. We haven't removed it because a bug in Ember prevented setting `type` HTML attribute on `<button>`. But that has been fixed.

## Migration

### Simple

```hbs
<BsButton @buttonType="submit">Submit</BsButton>
```

to

```hbs
<BsButton type="submit">Submit</BsButton>
```

### Forms

If dealing with a form, use the yielded `submitButton` component instead:

```hbs
<BsForm>
  <BsButton @buttonType="submit">submit</BsButton>
</BsForm>
```

to

```hbs
<BsForm as |form|>
  <form.submitButton>submit</form.submitButton>
</BsForm>
```