### PR TITLE
Allow multiple custom grid classes in horizontal layout

### DIFF
--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -189,7 +189,7 @@ export default class Form extends Component {
    */
 
   /**
-   * The Bootstrap grid classed for form labels. This is used by the `Components.FormElement` class as a default for the
+   * The Bootstrap grid classes for form labels. This is used by the `Components.FormElement` class as a default for the
    * whole form.
    *
    * @property horizontalLabelGridClass

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -189,7 +189,7 @@ export default class Form extends Component {
    */
 
   /**
-   * The Bootstrap grid class for form labels. This is used by the `Components.FormElement` class as a default for the
+   * The Bootstrap grid classed for form labels. This is used by the `Components.FormElement` class as a default for the
    * whole form.
    *
    * @property horizontalLabelGridClass

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -657,8 +657,8 @@ export default class FormElement extends Component {
    */
 
   /**
-   * The Bootstrap grid class for form labels within a horizontal layout form. Defaults to the value of the same
-   * property of the parent form. The corresponding grid class for form controls is automatically computed.
+   * The Bootstrap grid classes for form labels within a horizontal layout form. Defaults to the value of the same
+   * property of the parent form. The corresponding grid classes for form controls are automatically computed.
    *
    * @property horizontalLabelGridClass
    * @type string

--- a/addon/helpers/bs-form-horiz-input-class.js
+++ b/addon/helpers/bs-form-horiz-input-class.js
@@ -6,8 +6,14 @@ export default helper(function bsFormHorizInputClass([horizontalLabelGridClass] 
   if (isBlank(horizontalLabelGridClass)) {
     return undefined;
   }
-  let parts = horizontalLabelGridClass.split('-');
-  assert('horizontalInputGridClass must match format bootstrap grid column class', parts.length === 3);
-  parts[2] = 12 - parts[2];
-  return parts.join('-');
+
+  let originalClasses = horizontalLabelGridClass.split(' ');
+  let inputClasses = originalClasses.map((originalClass) => {
+    let parts = originalClass.split('-');
+    assert('horizontalInputGridClass must match format bootstrap grid column class', parts.length === 3);
+    parts[2] = 12 - parts[2];
+    return parts.join('-');
+  });
+
+  return inputClasses.join(' ');
 });

--- a/addon/helpers/bs-form-horiz-offset-class.js
+++ b/addon/helpers/bs-form-horiz-offset-class.js
@@ -5,8 +5,13 @@ export default helper(function bsFormHorizOffsetClass([horizontalLabelGridClass]
   if (isBlank(horizontalLabelGridClass)) {
     return undefined;
   }
-  let parts = horizontalLabelGridClass.split('-');
-  parts.splice(0, 1, 'offset');
+  let originalClasses = horizontalLabelGridClass.split(' ');
+  let offsetClasses = originalClasses.map((originalClass) => {
+    let parts = originalClass.split('-');
+    parts.splice(0, 1, 'offset');
 
-  return parts.join('-');
+    return parts.join('-');
+  });
+
+  return offsetClasses.join(' ');
 });

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -251,6 +251,19 @@ module('Integration | Component | bs-form/element', function (hooks) {
       assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
       assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
     });
+
+    test('supports horizontal form layout with multiple custom grid classes', async function (assert) {
+      await render(hbs`
+        <BsForm @formLayout="horizontal" as |form|>
+          <form.element @controlType="text" @label="some label" @options={{this.simpleOptions}} @horizontalLabelGridClass="col-md-3 col-lg-2" data-test-form-element />
+        </BsForm>
+      `);
+
+      assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
+      assert.dom('[data-test-form-element] > label').hasClass('col-lg-2');
+      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10');
+    });
   });
 
   module('controlType "textarea" is supported', function () {
@@ -281,6 +294,19 @@ module('Integration | Component | bs-form/element', function (hooks) {
 
       assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
       assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
+    });
+
+    test('supports horizontal form layout with multiple custom grid classes', async function (assert) {
+      await render(hbs`
+        <BsForm @formLayout="horizontal" as |form|>
+          <form.element @controlType="textarea" @label="some label" @options={{this.simpleOptions}} @horizontalLabelGridClass="col-md-3 col-lg-2" data-test-form-element />
+        </BsForm>
+      `);
+
+      assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
+      assert.dom('[data-test-form-element] > label').hasClass('col-lg-2');
+      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10');
     });
   });
 
@@ -313,6 +339,17 @@ module('Integration | Component | bs-form/element', function (hooks) {
       `);
 
       assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
+    });
+
+    test('supports horizontal form layout with multiple custom grid classes', async function (assert) {
+      await render(hbs`
+        <BsForm @formLayout="horizontal" as |form|>
+          <form.element @controlType="checkbox" @label="some label" @options={{this.simpleOptions}} @horizontalLabelGridClass="col-md-3 col-lg-2" data-test-form-element />
+        </BsForm>
+      `);
+
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
+      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10').hasClass('offset-lg-2');
     });
   });
 
@@ -374,6 +411,17 @@ module('Integration | Component | bs-form/element', function (hooks) {
       `);
 
       assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
+    });
+
+    test('supports horizontal form layout with multiple custom grid classes', async function (assert) {
+      await render(hbs`
+        <BsForm @formLayout="horizontal" as |form|>
+          <form.element @controlType="switch" @label="some label" @options={{this.simpleOptions}} @horizontalLabelGridClass="col-md-3 col-lg-2" data-test-form-element />
+        </BsForm>
+      `);
+
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
+      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10').hasClass('offset-lg-2');
     });
   });
 

--- a/tests/integration/components/bs-form/element-test.js
+++ b/tests/integration/components/bs-form/element-test.js
@@ -259,10 +259,8 @@ module('Integration | Component | bs-form/element', function (hooks) {
         </BsForm>
       `);
 
-      assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
-      assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
-      assert.dom('[data-test-form-element] > label').hasClass('col-lg-2');
-      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10');
+      assert.dom('[data-test-form-element] > label').hasClass('col-md-3').hasClass('col-lg-2');
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('col-lg-10');
     });
   });
 
@@ -303,10 +301,8 @@ module('Integration | Component | bs-form/element', function (hooks) {
         </BsForm>
       `);
 
-      assert.dom('[data-test-form-element] > label').hasClass('col-md-3');
-      assert.dom('[data-test-form-element] > div').hasClass('col-md-9');
-      assert.dom('[data-test-form-element] > label').hasClass('col-lg-2');
-      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10');
+      assert.dom('[data-test-form-element] > label').hasClass('col-md-3').hasClass('col-lg-2');
+      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('col-lg-10');
     });
   });
 
@@ -348,8 +344,12 @@ module('Integration | Component | bs-form/element', function (hooks) {
         </BsForm>
       `);
 
-      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
-      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10').hasClass('offset-lg-2');
+      assert
+        .dom('[data-test-form-element] > div')
+        .hasClass('col-md-9')
+        .hasClass('col-lg-10')
+        .hasClass('offset-md-3')
+        .hasClass('offset-lg-2');
     });
   });
 
@@ -420,8 +420,12 @@ module('Integration | Component | bs-form/element', function (hooks) {
         </BsForm>
       `);
 
-      assert.dom('[data-test-form-element] > div').hasClass('col-md-9').hasClass('offset-md-3');
-      assert.dom('[data-test-form-element] > div').hasClass('col-lg-10').hasClass('offset-lg-2');
+      assert
+        .dom('[data-test-form-element] > div')
+        .hasClass('col-md-9')
+        .hasClass('col-lg-10')
+        .hasClass('offset-md-3')
+        .hasClass('offset-lg-2');
     });
   });
 


### PR DESCRIPTION
This extends the logic for `horizontalLabelGridClass` to accept a string with multiple custom grid classes, e.g. `col-md-4 col-lg-2`.

I found this useful when adapting the form layout for multiple breakpoints.