### PR TITLE
Replace blacklist/whitelist with include/exclude in config (fixes #1154)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+*.hbs
+
 # unconventional js
 /blueprints/*/files/
 /vendor/

--- a/docs/app/templates/getting-started/setup.hbs
+++ b/docs/app/templates/getting-started/setup.hbs
@@ -125,27 +125,27 @@
       </td>
     </tr>
     <tr>
-      <td>whitelist</td>
+      <td>include</td>
       <td>Array of component names</td>
       <td></td>
       <td>
         <p>
           Component tree shaking: include only the listed components into your build, to reduce your JavaScript bundle size. Components not listed here will not be available.
-          You should use either <code>whitelist</code> or <code>blacklist</code>, not both.
+          You should use either <code>include</code> or <code>exclude</code>, not both.
         </p>
 
         <p>Example:</p>
-        <pre class="highlight"><code>whitelist: ['bs-button', 'bs-modal', 'bs-form']</code></pre>
+        <pre class="highlight"><code>include: ['bs-button', 'bs-modal', 'bs-form']</code></pre>
       </td>
     </tr>
     <tr>
-      <td>blacklist</td>
+      <td>exclude</td>
       <td>Array of component names</td>
       <td></td>
       <td>
         <p>
           Exclude the listed components from your build, to reduce your JavaScript bundle size. See
-          <code>whitelist</code>.
+          <code>include</code>.
         </p>
       </td>
     </tr>
@@ -162,7 +162,7 @@ module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     'ember-bootstrap': {
       importBootstrapCSS: false,
-      blacklist: ['bs-popover', 'bs-accordion']
+      exclude: ['bs-popover', 'bs-accordion']
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -222,20 +222,20 @@ module.exports = {
   },
 
   filterComponents(tree) {
-    let whitelist = this.generateWhitelist(this.bootstrapOptions.whitelist);
-    let blacklist = this.bootstrapOptions.blacklist || [];
+    let includeList = this.generateIncludeList(this.bootstrapOptions.include);
+    let excludeList = this.bootstrapOptions.exclude || [];
 
     // exit early if no opts defined
-    if (whitelist.length === 0 && blacklist.length === 0) {
+    if (includeList.length === 0 && excludeList.length === 0) {
       return tree;
     }
 
     return new Funnel(tree, {
-      exclude: [(name) => this.excludeComponent(name, whitelist, blacklist)],
+      exclude: [(name) => this.excludeComponent(name, includeList, excludeList)],
     });
   },
 
-  excludeComponent(name, whitelist, blacklist) {
+  excludeComponent(name, includeList, excludeList) {
     let regex = /^(templates\/)?components\/(base\/)?/;
     let isComponent = regex.test(name);
     if (!isComponent) {
@@ -250,38 +250,38 @@ module.exports = {
       baseName = baseName.substring(0, baseName.lastIndexOf('.'));
     }
 
-    let isWhitelisted = whitelist.indexOf(baseName) !== -1;
-    let isBlacklisted = blacklist.indexOf(baseName) !== -1;
+    let isIncluded = includeList.indexOf(baseName) !== -1;
+    let isExcluded = excludeList.indexOf(baseName) !== -1;
 
-    if (whitelist.length === 0 && blacklist.length === 0) {
+    if (includeList.length === 0 && excludeList.length === 0) {
       return false;
     }
 
-    if (whitelist.length && blacklist.length === 0) {
-      return !isWhitelisted;
+    if (includeList.length && excludeList.length === 0) {
+      return !isIncluded;
     }
 
-    return isBlacklisted;
+    return isExcluded;
   },
 
-  generateWhitelist(whitelist) {
+  generateIncludeList(includeList) {
     let list = [];
 
-    if (!whitelist) {
+    if (!includeList) {
       return list;
     }
 
-    function _addToWhitelist(item) {
+    function _addToIncludeList(item) {
       if (list.indexOf(item) === -1) {
         list.push(item);
 
         if (componentDependencies[item]) {
-          componentDependencies[item].forEach(_addToWhitelist);
+          componentDependencies[item].forEach(_addToIncludeList);
         }
       }
     }
 
-    whitelist.forEach(_addToWhitelist);
+    includeList.forEach(_addToIncludeList);
     return list;
   },
 };

--- a/index.js
+++ b/index.js
@@ -222,6 +222,13 @@ module.exports = {
   },
 
   filterComponents(tree) {
+    if (this.bootstrapOptions.whitelist) {
+      throw new SilentError('The `whitelist` option has been removed. Please use the `include` option instead.');
+    }
+    if (this.bootstrapOptions.blacklist) {
+      throw new SilentError('The `blacklist` option has been removed. Please use the `exclude` option instead.');
+    }
+
     let includeList = this.generateIncludeList(this.bootstrapOptions.include);
     let excludeList = this.bootstrapOptions.exclude || [];
 

--- a/node-tests/index-tests.js
+++ b/node-tests/index-tests.js
@@ -12,31 +12,31 @@ describe('index', function () {
       'templates/components/bs-accordion/item.hbs',
     ].forEach(function (name) {
       describe(`works for ${name}`, function () {
-        it('should return `true` if the file is in the blacklist', function () {
+        it('should return `true` if the file is in the `exclude` list', function () {
           let result = addonIndex.excludeComponent(name, [], ['bs-accordion']);
 
           expect(result).to.be.true;
         });
 
-        it('should return `false` if the file is not in the blacklist', function () {
+        it('should return `false` if the file is not in the `exclude` list', function () {
           let result = addonIndex.excludeComponent(name, [], ['bs-button']);
 
           expect(result).to.be.false;
         });
 
-        it('should return `false` if the file is in the whitelist', function () {
+        it('should return `false` if the file is in the `include` list', function () {
           let result = addonIndex.excludeComponent(name, ['bs-accordion'], []);
 
           expect(result).to.be.false;
         });
 
-        it('should return `true` if the file is not in the whitelist', function () {
+        it('should return `true` if the file is not in the `include` list', function () {
           let result = addonIndex.excludeComponent(name, ['bs-form'], []);
 
           expect(result).to.be.true;
         });
 
-        it('should return `true` if the file is in both the whitelist and blacklist', function () {
+        it('should return `true` if the file is in both the `include` list and `exclude` list', function () {
           let result = addonIndex.excludeComponent(name, ['bs-accordion'], ['bs-accordion']);
 
           expect(result).to.be.true;
@@ -51,15 +51,15 @@ describe('index', function () {
     });
   });
 
-  describe('whitelist', function () {
-    it('whitelist is correct for simple component', function () {
-      let result = addonIndex.generateWhitelist(['bs-button']);
+  describe('generateExcludeList', function () {
+    it('`include` list is correct for simple component', function () {
+      let result = addonIndex.generateExcludeList(['bs-button']);
 
       expect(result).to.deep.equal(['bs-button']);
     });
 
-    it('whitelist is correct for component with dependencies', function () {
-      let result = addonIndex.generateWhitelist(['bs-button-group']);
+    it('`include` list is correct for component with dependencies', function () {
+      let result = addonIndex.generateExcludeList(['bs-button-group']);
 
       expect(result).to.deep.equal(['bs-button-group', 'bs-button']);
     });

--- a/node-tests/index-tests.js
+++ b/node-tests/index-tests.js
@@ -51,14 +51,32 @@ describe('index', function () {
     });
   });
 
+  describe('filterComponents', function () {
+    it('throws an error if the `whitelist` option is used', function () {
+      addonIndex.bootstrapOptions = { whitelist: ['bs-button'] };
+
+      expect(addonIndex.filterComponents.bind(addonIndex)).to.throw(
+        'The `whitelist` option has been removed. Please use the `include` option instead.'
+      );
+    });
+
+    it('throws an error if the `blacklist` option is used', function () {
+      addonIndex.bootstrapOptions = { blacklist: ['bs-button'] };
+
+      expect(addonIndex.filterComponents.bind(addonIndex)).to.throw(
+        'The `blacklist` option has been removed. Please use the `exclude` option instead.'
+      );
+    });
+  });
+
   describe('generateIncludeList', function () {
-    it('`include` list is correct for simple component', function () {
+    it('include list is correct for simple component', function () {
       let result = addonIndex.generateIncludeList(['bs-button']);
 
       expect(result).to.deep.equal(['bs-button']);
     });
 
-    it('`include` list is correct for component with dependencies', function () {
+    it('include list is correct for component with dependencies', function () {
       let result = addonIndex.generateIncludeList(['bs-button-group']);
 
       expect(result).to.deep.equal(['bs-button-group', 'bs-button']);

--- a/node-tests/index-tests.js
+++ b/node-tests/index-tests.js
@@ -51,15 +51,15 @@ describe('index', function () {
     });
   });
 
-  describe('generateExcludeList', function () {
+  describe('generateIncludeList', function () {
     it('`include` list is correct for simple component', function () {
-      let result = addonIndex.generateExcludeList(['bs-button']);
+      let result = addonIndex.generateIncludeList(['bs-button']);
 
       expect(result).to.deep.equal(['bs-button']);
     });
 
     it('`include` list is correct for component with dependencies', function () {
-      let result = addonIndex.generateExcludeList(['bs-button-group']);
+      let result = addonIndex.generateIncludeList(['bs-button-group']);
 
       expect(result).to.deep.equal(['bs-button-group', 'bs-button']);
     });


### PR DESCRIPTION
Use more inclusive language by replacing `blacklist` and `whitelist` in the configuration options with `exclude` and `include` (as was decided in #1154).

> **Warning**: This a **breaking change** currently. I noticed a new major version is in the works so I didn’t bother to make it backwards compatible, but this could easily be done if that’s preferred.

Also in this PR (but unrelated) is a change to the `.prettierignore` to add `*.hbs` since my editor (VS Code) kept trying to prettify hbs files on save.