### PR TITLE
bs-dropdown dynamic positioning should not be used when in a navbar

### DIFF
--- a/addon/components/bs-dropdown.hbs
+++ b/addon/components/bs-dropdown.hbs
@@ -25,6 +25,7 @@
         )
         menu=(component (ensure-safe-component (bs-default @menuComponent (component "bs-dropdown/menu")))
           isOpen=this.isOpen
+          inNav=@inNav
           direction=this.direction
           toggleElement=this.toggleElement
           registerChildElement=this.registerChildElement

--- a/addon/components/bs-dropdown/menu.js
+++ b/addon/components/bs-dropdown/menu.js
@@ -71,6 +71,15 @@ export default class DropdownMenu extends Component {
   }
 
   /**
+   * @property inNav
+   * @type {boolean}
+   * @private
+   */
+  get inNav() {
+    return this.args.inNav ?? false;
+  }
+
+  /**
    * @property _renderInPlace
    * @type boolean
    * @private
@@ -151,6 +160,10 @@ export default class DropdownMenu extends Component {
         {
           name: 'flip',
           enabled: this.flip,
+        },
+        {
+          name: 'applyStyles',
+          enabled: !this.inNav,
         },
       ],
     };

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -442,22 +442,30 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('dropdown in nav disables dynamic positioning', async function (assert) {
-    await render(hbs`
-    <BsDropdown @inNav={{true}} as |dd|>
-      <dd.toggle>Dropdown</dd.toggle>
-      <dd.menu as |menu|>
-        <menu.item>
-          <menu.link-to @route="index">Home</menu.link-to>
-        </menu.item>
-      </dd.menu>
-    </BsDropdown>`);
+    this.set('inNav', false);
+
+    await render(hbs`<BsDropdown @inNav={{this.inNav}} as |dd|>
+  <dd.toggle>Dropdown</dd.toggle>
+  <dd.menu as |menu|>
+    <menu.item>
+      <menu.link-to @route='index'>Home</menu.link-to>
+    </menu.item>
+  </dd.menu>
+</BsDropdown>`);
 
     await click('a.dropdown-toggle');
 
-    assert.equal(
+    assert.ok(
+      this.element.querySelector('.dropdown-menu').style.length > 0,
+      'Dynamic positioning applied when inNav is set to false',
+    );
+
+    this.set('inNav', true);
+
+    assert.strictEqual(
       this.element.querySelector('.dropdown-menu').style.length,
       0,
-      'Dynamic positioning not applied when inNav is set to true'
+      'Dynamic positioning not applied when inNav is set to true',
     );
   });
 

--- a/tests/integration/components/bs-dropdown-test.js
+++ b/tests/integration/components/bs-dropdown-test.js
@@ -441,6 +441,26 @@ module('Integration | Component | bs-dropdown', function (hooks) {
     );
   });
 
+  test('dropdown in nav disables dynamic positioning', async function (assert) {
+    await render(hbs`
+    <BsDropdown @inNav={{true}} as |dd|>
+      <dd.toggle>Dropdown</dd.toggle>
+      <dd.menu as |menu|>
+        <menu.item>
+          <menu.link-to @route="index">Home</menu.link-to>
+        </menu.item>
+      </dd.menu>
+    </BsDropdown>`);
+
+    await click('a.dropdown-toggle');
+
+    assert.equal(
+      this.element.querySelector('.dropdown-menu').style.length,
+      0,
+      'Dynamic positioning not applied when inNav is set to true'
+    );
+  });
+
   test('dropdown menu can be rendered in a wormhole', async function (assert) {
     await render(
       hbs`<div id='ember-bootstrap-wormhole'></div>

--- a/tests/integration/components/bs-nav-test.js
+++ b/tests/integration/components/bs-nav-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { test } from '../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
@@ -59,6 +59,13 @@ module('Integration | Component | bs-nav', function (hooks) {
     assert
       .dom('.nav > li.dropdown')
       .exists({ count: 1 }, 'it has a dropdown as a nav item');
+
+    await click('.nav a.dropdown-toggle');
+    assert.equal(
+      this.element.querySelector('.nav > li.dropdown .dropdown-menu').style.length,
+      0,
+      'Dynamic positioning not applied when inNav is set to true'
+    );
   });
 
   test('it passes accessibility checks', async function (assert) {

--- a/tests/integration/components/bs-nav-test.js
+++ b/tests/integration/components/bs-nav-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | bs-nav', function (hooks) {
   <nav.dropdown as |dd|>
     <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
     <dd.menu as |ddm|>
-      <ddm.item>{{#ddm.link-to 'index'}}Home{{/ddm.link-to}}</ddm.item>
+      <ddm.item><ddm.link-to @route='index'>Home</ddm.link-to></ddm.item>
     </dd.menu>
   </nav.dropdown>
 </BsNav>`);
@@ -61,10 +61,11 @@ module('Integration | Component | bs-nav', function (hooks) {
       .exists({ count: 1 }, 'it has a dropdown as a nav item');
 
     await click('.nav a.dropdown-toggle');
-    assert.equal(
-      this.element.querySelector('.nav > li.dropdown .dropdown-menu').style.length,
+    assert.strictEqual(
+      this.element.querySelector('.nav > li.dropdown .dropdown-menu').style
+        .length,
       0,
-      'Dynamic positioning not applied when inNav is set to true'
+      'Dynamic positioning not applied when inNav is set to true',
     );
   });
 


### PR DESCRIPTION
fixes https://github.com/ember-bootstrap/ember-bootstrap/issues/1945

Bootstrap 5 (and 4) do not use popper to position dropdowns that are in navs. The bootstrap dropdown js detects if it is in a nav or specified to be static and instructs Popper to not apply any styles ([here's the dropdown disable code](https://github.com/twbs/bootstrap/blob/8fcfce1ebd988fd4e5ed2f51acaa5c49e6b301c9/js/src/dropdown.js#L312-L319)).

This change uses the existing `inNav` flag and passes it to the dropdown menu component and uses that to disable popper's styles in the same method as bootstrap.