### PR TITLE
clean-up leftovers from removed @buttonType argument of BsButton

### DIFF
--- a/addon/components/bs-button-group/button.hbs
+++ b/addon/components/bs-button-group/button.hbs
@@ -29,7 +29,7 @@
 {{else}}
   <button
     disabled={{this.__disabled}}
-    type={{this.buttonType}}
+    type="button"
     class="btn {{if this.active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default="secondary" outline=@outline}}"
     ...attributes
     {{on "click" this.handleClick}}

--- a/addon/components/bs-dropdown/button.hbs
+++ b/addon/components/bs-dropdown/button.hbs
@@ -2,6 +2,7 @@
   disabled={{this.__disabled}}
   aria-expanded={{if @isOpen "true" "false"}}
   class="btn dropdown-toggle {{if @active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
+  type="button"
   ...attributes
   {{on "click" this.handleClick}}
   {{on "keydown" @onKeyDown}}

--- a/addon/components/bs-dropdown/button.hbs
+++ b/addon/components/bs-dropdown/button.hbs
@@ -1,6 +1,5 @@
 <button
   disabled={{this.__disabled}}
-  type={{this.buttonType}}
   aria-expanded={{if @isOpen "true" "false"}}
   class="btn dropdown-toggle {{if @active "active"}} {{if this.block "btn-block"}} {{bs-size-class "btn" @size}} {{bs-type-class "btn" @type default=(if (macroCondition (macroGetOwnConfig "isBS3")) "default" "secondary") outline=@outline}}"
   ...attributes

--- a/addon/components/bs-form.js
+++ b/addon/components/bs-form.js
@@ -21,7 +21,7 @@ import { ref } from 'ember-ref-bucket';
 
   ### Submitting the form
 
-  The form yields a `submitButton` component, which is a preconfigured `<BsButton>` with `@type="primary"` and `@buttonType="submit"`.
+  The form yields a `submitButton` component, which is a preconfigured `<BsButton>` with `@type="primary"` and `type="submit"`.
   The button is disabled while a form submission is pending. Additionally, the button state is bound to the form submission state.
 
   ```hbs

--- a/addon/components/bs-form/element.js
+++ b/addon/components/bs-form/element.js
@@ -113,7 +113,7 @@ import { dedupeTracked } from 'tracked-toolbox';
     <form.element @controlType="email" @label="Email" @property="email" />
     <form.element @controlType="password" @label="Password" @property="password" />
     <form.element @controlType="checkbox" @label="Remember me" @property="rememberMe" />
-    <BsButton @defaultText="Submit" @type="primary" @buttonType="submit" />
+    <form.submitButton>Submit</form.submitButton>
   </BsForm>
   ```
 

--- a/tests/dummy/app/templates/fastboot/forms.hbs
+++ b/tests/dummy/app/templates/fastboot/forms.hbs
@@ -1,4 +1,4 @@
 <BsForm @model={{this}} as |form|>
   <form.element @controlType="email" @label="Email" @placeholder="Email" @property="email" @required={{true}} />
-  <BsButton @defaultText="Submit" @type="primary" @buttonType="submit" />
+  <BsButton @defaultText="Submit" @type="primary" type="submit" />
 </BsForm>


### PR DESCRIPTION
`@buttonType` argument of `<BsForm>` was removed in #1913. But some clean-up work was missed.