### PR TITLE
build docs app for testing in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,14 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: docs
-      - name: Run Tests
+      - name: Run Ember Tests
         run: yarn test
         working-directory: docs
+      - name: Build including API docs
+        run: yarn run docs:build
+      # TODO: Perform some basic steps that the build contains API docs
+      #       and works as expected.
+
 #  test-browserstack:
 #    name: Browserstack Tests
 #    runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,6 @@ on:
     types:
       - published
       - edited
-  workflow_run:
-    workflows:
-      - CI
 
 jobs:
   build:


### PR DESCRIPTION
Building the docs app in `Publish docs` app was confusing. Even though the build was not uploaded, it looked strange. Also the status was not reported in the pull requests. So it didn't had much value after all.

Changing the setup here to build the docs app as part of the `test-docs` CI job. In a later step we could even add some assertions that the build contains API docs as expected etc. But that's something for later.

Closes #1899 