### PR TITLE
Revert "RenovateBot should not pin dependencies"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>kaliber5/renovate-config:ember-addon",
-    ":preserveSemverRanges"
+    "local>kaliber5/renovate-config:ember-addon"
   ]
 }


### PR DESCRIPTION
RenovateBot should pin the dependencies. Reasons are well explained here: https://docs.renovatebot.com/dependency-pinning/