### PR TITLE
do not require Bootstrap dep unless importing it through this addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,11 +84,13 @@ module.exports = {
     if (!this.hasPreprocessor()) {
       // / Import css from bootstrap
       if (options.importBootstrapCSS) {
+        this.needsBootstrapStyles = true;
         this.import(path.join(vendorPath, 'bootstrap.css'));
         this.import(path.join(vendorPath, 'bootstrap.css.map'), { destDir: 'assets' });
       }
 
       if (options.importBootstrapTheme) {
+        this.needsBootstrapStyles = true;
         this.import(path.join(vendorPath, 'bootstrap-theme.css'));
         this.import(path.join(vendorPath, 'bootstrap-theme.css.map'), { destDir: 'assets' });
       }
@@ -168,7 +170,7 @@ module.exports = {
   treeForVendor(tree) {
     let trees = [tree];
 
-    if (!this.hasPreprocessor()) {
+    if (!this.hasPreprocessor() && this.needsBootstrapStyles) {
       trees.push(
         new Funnel(this.getBootstrapStylesPath(), {
           destDir: 'ember-bootstrap',


### PR DESCRIPTION
A consumer may import Bootstrap differently than through this addon. E.g. consumer may pull it from a CDN. Or import precompiled Bootstrap CSS with applied template from another package. A dependency on `bootstrap` NPM package is not needed in this cases. But Ember Bootstrap expected the dependency to exist anyways as it tried to pull in files from Bootstrap into the build (even if not importing them to the build output). This change allows consumers to drop `bootstrap` dependency if `importBootstrapCSS` and `importBootstrapTheme` are `false` _and_ not using a precompiler.

There are still some rough edges if using a precompiler. E.g. `importBootstrapCSS` and `importBootstrapTheme` are ignored if using a precompiler. And `bootstrap` dependency is required if using a precompiler regardless if Boostrap is imported with that precompiler. That are issues to be picked up in a follow-up PRs.

Fixes #1903.