### PR TITLE
ember-unique-id-helper-polyfill is not needed anymove

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",
     "ember-render-helpers": "^0.2.0",
     "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
-    "ember-unique-id-helper-polyfill": "^1.2.2",
     "findup-sync": "^5.0.0",
     "fs-extra": "^11.0.0",
     "resolve": "^1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5402,7 +5402,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -6221,15 +6221,6 @@ ember-try@3.0.0:
     rimraf "^3.0.2"
     semver "^7.5.4"
     walk-sync "^2.2.0"
-
-ember-unique-id-helper-polyfill@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ember-unique-id-helper-polyfill/-/ember-unique-id-helper-polyfill-1.2.2.tgz#64ab71b378cca117aa7d56d4275f47ff3b830b6d"
-  integrity sha512-gjcwTBkCDUA0iYFS7aArfJub+eos/itxEsC399JUbdKNIBJLesB/1OHnmxLLwExZHp7gyHuiDFOPcknafhFm3g==
-  dependencies:
-    broccoli-funnel "^3.0.8"
-    ember-cli-babel "^7.26.10"
-    ember-cli-version-checker "^5.1.2"
 
 emoji-regex@^10.2.1:
   version "10.3.0"


### PR DESCRIPTION
Ember ships `unique-id` helper since 4.4. We dropped supported for Ember < 4.8 in #1996. The `unique-id` helper polyfill is not needed anymore.