### PR TITLE
Drop dependency resolution overwrite not needed anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
   "lint-staged": {
     "*.js": "eslint --cache --fix"
   },
-  "resolutions": {
-    "ember-cli-htmlbars/semver": "~7.5.0"
-  },
   "dependencies": {
     "@ember/render-modifiers": "^2.0.0",
     "@embroider/macros": "^1.0.0",


### PR DESCRIPTION
This was added long ago to keep support for Node 8, which was dropped by `semver` in a minor release. See https://github.com/ember-bootstrap/ember-bootstrap/pull/964#discussion_r365226016 for history.

The resolution is not needed anymore since a long time.