### PR TITLE
Run pre-commit lint hook with pnpm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn run lint-staged
+pnpm run lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm run lint-staged
+pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "lint-staged": "lint-staged",
     "nodetest": "mocha node-tests --recursive",
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
-    "lint-staged": "lint-staged",
     "nodetest": "mocha node-tests --recursive",
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",


### PR DESCRIPTION
It seems like this was missed during the yarn -> pnpm conversion (#2028).