### PR TITLE
support ember-style-modifier v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",
     "ember-render-helpers": "^0.2.0",
-    "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
+    "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "findup-sync": "^5.0.0",
     "fs-extra": "^11.0.0",
     "resolve": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ dependencies:
     specifier: ^0.2.0
     version: 0.2.0
   ember-style-modifier:
-    specifier: ^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0
+    specifier: ^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
     version: 3.0.1(@ember/string@3.1.1)(ember-source@5.5.0)(webpack@5.89.0)
   findup-sync:
     specifier: ^5.0.0


### PR DESCRIPTION
Support [`ember-style-modifier` v4](https://github.com/jelhan/ember-style-modifier/releases/tag/v4.0.0), which has been released earlier this week. Breaking changes are limited to supported Ember and node versions. No changes to public API of `{{style}}` modifier were introduced.