### PR TITLE
upgrade husky to v9 per migration guides

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "docs:build": "pnpm --filter ember-bootstrap-docs docs:build",
-    "prepare": "husky install",
+    "prepare": "husky",
     "lint": "pnpm --recursive lint",
     "lint:fix": "pnpm --recursive lint:fix",
     "test": "concurrently \"npm:test:*\"",


### PR DESCRIPTION
Following upgrade guide for Husky v9: https://github.com/typicode/husky/releases/tag/v9.0.1

Husky v9 is backward compatible. The current configuration works. This is only to be future proof. And because I just had read that changelog entry when merging the upgrade MR.