### PR TITLE
Convert docs components to native classes

### DIFF
--- a/docs/app/controllers/application.js
+++ b/docs/app/controllers/application.js
@@ -1,9 +1,0 @@
-import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
-import { match } from '@ember/object/computed';
-
-export default Controller.extend({
-  router: service(),
-
-  hideNav: match('router.currentRouteName', /acceptance/),
-});

--- a/docs/app/controllers/demo.js
+++ b/docs/app/controllers/demo.js
@@ -1,25 +1,28 @@
 import { inject as service } from '@ember/service';
-import { readOnly, notEmpty } from '@ember/object/computed';
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
+import { isEmpty } from '@ember/utils';
 
-export default Controller.extend({
-  router: service(),
-  component: service(),
-  currentRouteName: readOnly('router.currentRouteName'),
+export default class DemoController extends Controller {
+  @service
+  router;
 
-  isDetailPage: notEmpty('currentComponent'),
+  @service
+  component;
 
-  currentComponent: computed(
-    'component.models',
-    'currentRouteName',
-    function () {
-      let routeName = this.currentRouteName;
-      let routeParts = routeName.split('.');
-      if (routeParts.length > 2) {
-        routeName = routeParts.slice(0, 2).join('.');
-      }
-      return this.component.models.findBy('demoRoute', routeName);
-    },
-  ),
-});
+  get currentRouteName() {
+    return this.router.currentRouteName;
+  }
+
+  get isDetailPage() {
+    return !isEmpty(this.currentComponent);
+  }
+
+  get currentComponent() {
+    let routeName = this.currentRouteName;
+    let routeParts = routeName.split('.');
+    if (routeParts.length > 2) {
+      routeName = routeParts.slice(0, 2).join('.');
+    }
+    return this.component.models.find((model) => model.demoRoute === routeName);
+  }
+}

--- a/docs/app/controllers/demo/alert.js
+++ b/docs/app/controllers/demo/alert.js
@@ -1,12 +1,22 @@
-import { oneWay } from '@ember/object/computed';
 import Controller from '@ember/controller';
-import { A } from '@ember/array';
+import { tracked } from '@glimmer/tracking';
 
-export default Controller.extend({
-  visible: true,
-  fade: true,
-  dismissible: true,
-  headerTag: 'h4',
-  type: oneWay('typeChoices.firstObject'),
-  typeChoices: A(['success', 'info', 'warning', 'danger']),
-});
+export default class AlertController extends Controller {
+  @tracked
+  visible = true;
+
+  @tracked
+  fade = true;
+
+  @tracked
+  dismissible = true;
+
+  @tracked
+  headerTag = 'h4';
+
+  @tracked
+  typeChoices = ['success', 'info', 'warning', 'danger'];
+
+  @tracked
+  type = this.typeChoices[0];
+}

--- a/docs/app/controllers/demo/carousel.js
+++ b/docs/app/controllers/demo/carousel.js
@@ -1,41 +1,58 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-export default Controller.extend({
-  _slides: null,
-  wrap: true,
-  init() {
-    this._super(...arguments);
-    this.set('_slides', [
-      {
-        alt: 'First slide',
-        src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNzc3OiM1NTUvdGV4dDpGaXJzdCBzbGlkZQpDcmVhdGVkIHdpdGggSG9sZGVyLmpzIDIuNi4wLgpMZWFybiBtb3JlIGF0IGh0dHA6Ly9ob2xkZXJqcy5jb20KKGMpIDIwMTItMjAxNSBJdmFuIE1hbG9waW5za3kgLSBodHRwOi8vaW1za3kuY28KLS0+PGRlZnM+PHN0eWxlIHR5cGU9InRleHQvY3NzIj48IVtDREFUQVsjaG9sZGVyXzE1Y2ZlYzcyYmI5IHRleHQgeyBmaWxsOiM1NTU7Zm9udC13ZWlnaHQ6Ym9sZDtmb250LWZhbWlseTpBcmlhbCwgSGVsdmV0aWNhLCBPcGVuIFNhbnMsIHNhbnMtc2VyaWYsIG1vbm9zcGFjZTtmb250LXNpemU6NDVwdCB9IF1dPjwvc3R5bGU+PC9kZWZzPjxnIGlkPSJob2xkZXJfMTVjZmVjNzJiYjkiPjxyZWN0IHdpZHRoPSI5MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjNzc3Ii8+PGc+PHRleHQgeD0iMzA4IiB5PSIyNjcuMSI+Rmlyc3Qgc2xpZGU8L3RleHQ+PC9nPjwvZz48L3N2Zz4=',
-      },
-      {
-        alt: 'Second slide',
-        src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNjY2OiM0NDQvdGV4dDpTZWNvbmQgc2xpZGUKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNWNmZWM3NGFmMSB0ZXh0IHsgZmlsbDojNDQ0O2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjQ1cHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1Y2ZlYzc0YWYxIj48cmVjdCB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgZmlsbD0iIzY2NiIvPjxnPjx0ZXh0IHg9IjI2NC41IiB5PSIyNjcuMSI+U2Vjb25kIHNsaWRlPC90ZXh0PjwvZz48L2c+PC9zdmc+',
-      },
-      {
-        alt: 'Third slide',
-        src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNTU1OiMzMzMvdGV4dDpUaGlyZCBzbGlkZQpDcmVhdGVkIHdpdGggSG9sZGVyLmpzIDIuNi4wLgpMZWFybiBtb3JlIGF0IGh0dHA6Ly9ob2xkZXJqcy5jb20KKGMpIDIwMTItMjAxNSBJdmFuIE1hbG9waW5za3kgLSBodHRwOi8vaW1za3kuY28KLS0+PGRlZnM+PHN0eWxlIHR5cGU9InRleHQvY3NzIj48IVtDREFUQVsjaG9sZGVyXzE1Y2ZlYzZmYWFmIHRleHQgeyBmaWxsOiMzMzM7Zm9udC13ZWlnaHQ6Ym9sZDtmb250LWZhbWlseTpBcmlhbCwgSGVsdmV0aWNhLCBPcGVuIFNhbnMsIHNhbnMtc2VyaWYsIG1vbm9zcGFjZTtmb250LXNpemU6NDVwdCB9IF1dPjwvc3R5bGU+PC9kZWZzPjxnIGlkPSJob2xkZXJfMTVjZmVjNmZhYWYiPjxyZWN0IHdpZHRoPSI5MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjNTU1Ii8+PGc+PHRleHQgeD0iMjk3LjUiIHk9IjI2Ny4xIj5UaGlyZCBzbGlkZTwvdGV4dD48L2c+PC9nPjwvc3ZnPg==',
-      },
-    ]);
-  },
-  integerIndex: computed('index', function () {
-    return parseInt(this.index, 10);
-  }),
-  integerInterval: computed('interval', function () {
-    return parseInt(this.interval, 10);
-  }),
-  index: 0,
-  interval: 5000,
-  keyboard: true,
-  slides: computed('_slides', 'numberOfSlides', function () {
+export default class CarouselController extends Controller {
+  _slides = [
+    {
+      alt: 'First slide',
+      src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNzc3OiM1NTUvdGV4dDpGaXJzdCBzbGlkZQpDcmVhdGVkIHdpdGggSG9sZGVyLmpzIDIuNi4wLgpMZWFybiBtb3JlIGF0IGh0dHA6Ly9ob2xkZXJqcy5jb20KKGMpIDIwMTItMjAxNSBJdmFuIE1hbG9waW5za3kgLSBodHRwOi8vaW1za3kuY28KLS0+PGRlZnM+PHN0eWxlIHR5cGU9InRleHQvY3NzIj48IVtDREFUQVsjaG9sZGVyXzE1Y2ZlYzcyYmI5IHRleHQgeyBmaWxsOiM1NTU7Zm9udC13ZWlnaHQ6Ym9sZDtmb250LWZhbWlseTpBcmlhbCwgSGVsdmV0aWNhLCBPcGVuIFNhbnMsIHNhbnMtc2VyaWYsIG1vbm9zcGFjZTtmb250LXNpemU6NDVwdCB9IF1dPjwvc3R5bGU+PC9kZWZzPjxnIGlkPSJob2xkZXJfMTVjZmVjNzJiYjkiPjxyZWN0IHdpZHRoPSI5MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjNzc3Ii8+PGc+PHRleHQgeD0iMzA4IiB5PSIyNjcuMSI+Rmlyc3Qgc2xpZGU8L3RleHQ+PC9nPjwvZz48L3N2Zz4=',
+    },
+    {
+      alt: 'Second slide',
+      src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNjY2OiM0NDQvdGV4dDpTZWNvbmQgc2xpZGUKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNWNmZWM3NGFmMSB0ZXh0IHsgZmlsbDojNDQ0O2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjQ1cHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1Y2ZlYzc0YWYxIj48cmVjdCB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgZmlsbD0iIzY2NiIvPjxnPjx0ZXh0IHg9IjI2NC41IiB5PSIyNjcuMSI+U2Vjb25kIHNsaWRlPC90ZXh0PjwvZz48L2c+PC9zdmc+',
+    },
+    {
+      alt: 'Third slide',
+      src: 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iOTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDkwMCA1MDAiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPjwhLS0KU291cmNlIFVSTDogaG9sZGVyLmpzLzkwMHg1MDAvYXV0by8jNTU1OiMzMzMvdGV4dDpUaGlyZCBzbGlkZQpDcmVhdGVkIHdpdGggSG9sZGVyLmpzIDIuNi4wLgpMZWFybiBtb3JlIGF0IGh0dHA6Ly9ob2xkZXJqcy5jb20KKGMpIDIwMTItMjAxNSBJdmFuIE1hbG9waW5za3kgLSBodHRwOi8vaW1za3kuY28KLS0+PGRlZnM+PHN0eWxlIHR5cGU9InRleHQvY3NzIj48IVtDREFUQVsjaG9sZGVyXzE1Y2ZlYzZmYWFmIHRleHQgeyBmaWxsOiMzMzM7Zm9udC13ZWlnaHQ6Ym9sZDtmb250LWZhbWlseTpBcmlhbCwgSGVsdmV0aWNhLCBPcGVuIFNhbnMsIHNhbnMtc2VyaWYsIG1vbm9zcGFjZTtmb250LXNpemU6NDVwdCB9IF1dPjwvc3R5bGU+PC9kZWZzPjxnIGlkPSJob2xkZXJfMTVjZmVjNmZhYWYiPjxyZWN0IHdpZHRoPSI5MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjNTU1Ii8+PGc+PHRleHQgeD0iMjk3LjUiIHk9IjI2Ny4xIj5UaGlyZCBzbGlkZTwvdGV4dD48L2c+PC9nPjwvc3ZnPg==',
+    },
+  ];
+
+  @tracked
+  wrap = true;
+
+  @tracked
+  index = 0;
+
+  @tracked
+  interval = 5000;
+
+  @tracked
+  keyboard = true;
+
+  @tracked
+  ltr = true;
+
+  @tracked
+  numberOfSlides = 3;
+
+  @tracked
+  pauseOnMouseEnter = true;
+
+  @tracked
+  showControls = true;
+
+  @tracked
+  showIndicators = true;
+
+  get slides() {
     return this._slides.slice(0, this.numberOfSlides);
-  }),
-  ltr: true,
-  numberOfSlides: 3,
-  pauseOnMouseEnter: true,
-  showControls: true,
-  showIndicators: true,
-});
+  }
+
+  get integerIndex() {
+    return parseInt(`${this.index}`, 10);
+  }
+
+  get integerInterval() {
+    return parseInt(`${this.interval}`, 10);
+  }
+}

--- a/docs/app/controllers/demo/collapse.js
+++ b/docs/app/controllers/demo/collapse.js
@@ -1,13 +1,17 @@
-import { not } from '@ember/object/computed';
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-export default Controller.extend({
-  collapsed: true,
-  notCollapsed: not('collapsed'),
+export default class CollapseController extends Controller {
+  @tracked
+  collapsed = true;
 
-  actions: {
-    toggle() {
-      this.toggleProperty('collapsed');
-    },
-  },
-});
+  get notCollapsed() {
+    return !this.collapsed;
+  }
+
+  @action
+  toggle() {
+    this.collapsed = !this.collapsed;
+  }
+}

--- a/docs/app/models/login.js
+++ b/docs/app/models/login.js
@@ -1,6 +1,7 @@
 // BEGIN-SNIPPET login-model
 import EmberObject from '@ember/object';
 import { validator, buildValidations } from 'ember-cp-validations';
+import { tracked } from '@glimmer/tracking';
 
 const Validations = buildValidations({
   password: [
@@ -18,9 +19,8 @@ const Validations = buildValidations({
   email: [validator('presence', true), validator('format', { type: 'email' })],
 });
 
-export default EmberObject.extend(Validations, {
-  email: null,
-  password: null,
-  rememberMe: false,
-});
+export default class Login extends EmberObject.extend(Validations) {
+  @tracked email = null;
+  @tracked password = null;
+}
 // END-SNIPPET

--- a/docs/app/routes/changelog.js
+++ b/docs/app/routes/changelog.js
@@ -1,9 +1,9 @@
 import Route from '@ember/routing/route';
 import fetch from 'fetch';
 
-export default Route.extend({
+export default class ChangelogRoute extends Route {
   async model() {
     let response = await fetch('/CHANGELOG.md');
     return response.text();
-  },
-});
+  }
+}

--- a/docs/app/routes/demo.js
+++ b/docs/app/routes/demo.js
@@ -1,10 +1,10 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  component: service(),
+export default class DemoRoute extends Route {
+  @service component;
 
   model() {
     return this.component.findAll();
-  },
-});
+  }
+}

--- a/docs/app/services/component.js
+++ b/docs/app/services/component.js
@@ -123,14 +123,14 @@ const componentData = A([
 
 const components = A(componentData.map((data) => new Component(data)));
 
-export default Service.extend({
-  models: components,
+export default class ComponentService extends Service {
+  models = components;
 
   findAll() {
     return components;
-  },
+  }
 
   find(id) {
     return components.findBy('id', id);
-  },
-});
+  }
+}

--- a/docs/app/templates/application.hbs
+++ b/docs/app/templates/application.hbs
@@ -1,85 +1,78 @@
-{{#unless this.hideNav}}
-  <BsNavbar
-    @fluid={{false}}
-    @type="dark"
-    @backgroundColor="primary"
-    as |navbar|
-  >
-    <LinkTo @route="index" class="navbar-brand">
-      ember-bootstrap
-    </LinkTo>
-    <navbar.toggle />
-    <navbar.content class="justify-content-between">
-      <navbar.nav as |nav|>
-        <nav.item>
-          <nav.link-to @route="getting-started">
-            Getting Started
-          </nav.link-to>
-        </nav.item>
-        <nav.item>
-          <nav.link-to @route="demo">
-            Components
-          </nav.link-to>
-        </nav.item>
-        <nav.item>
-          <a href="/api" class="nav-link">
-            API
-          </a>
-        </nav.item>
-        <nav.item>
-          <nav.link-to @route="addons">
-            Addons
-          </nav.link-to>
-        </nav.item>
-      </navbar.nav>
-      <navbar.nav as |nav|>
-        <nav.item>
-          <a
-            href="https://discord.gg/zT3asNS"
-            class="nav-link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <i class="fab fa-discord"></i>
-            e-bootstrap
-          </a>
-        </nav.item>
-        <nav.item>
-          <a
-            href="https://twitter.com/simonihmig"
-            class="nav-link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <i class="fab fa-twitter"></i>
-          </a>
-        </nav.item>
-        <nav.item class="visible-sm-block visible-xs-block">
-          <a
-            href="https://github.com/kaliber5/ember-bootstrap"
-            class="nav-link"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <i class="fab fa-github"></i>
-          </a>
-        </nav.item>
-        <nav.item class="hidden-sm hidden-xs">
-          <div class="navbar-text">
-            <iframe
-              src="https://ghbtns.com/github-btn.html?user=kaliber5&repo=ember-bootstrap&type=star&count=true"
-              frameborder="0"
-              scrolling="0"
-              width="100px"
-              height="20px"
-              title="Github Stars"
-            ></iframe>
-          </div>
-        </nav.item>
-      </navbar.nav>
-    </navbar.content>
-  </BsNavbar>
-{{/unless}}
+<BsNavbar @fluid={{false}} @type="dark" @backgroundColor="primary" as |navbar|>
+  <LinkTo @route="index" class="navbar-brand">
+    ember-bootstrap
+  </LinkTo>
+  <navbar.toggle />
+  <navbar.content class="justify-content-between">
+    <navbar.nav as |nav|>
+      <nav.item>
+        <nav.link-to @route="getting-started">
+          Getting Started
+        </nav.link-to>
+      </nav.item>
+      <nav.item>
+        <nav.link-to @route="demo">
+          Components
+        </nav.link-to>
+      </nav.item>
+      <nav.item>
+        <a href="/api" class="nav-link">
+          API
+        </a>
+      </nav.item>
+      <nav.item>
+        <nav.link-to @route="addons">
+          Addons
+        </nav.link-to>
+      </nav.item>
+    </navbar.nav>
+    <navbar.nav as |nav|>
+      <nav.item>
+        <a
+          href="https://discord.gg/zT3asNS"
+          class="nav-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <i class="fab fa-discord"></i>
+          e-bootstrap
+        </a>
+      </nav.item>
+      <nav.item>
+        <a
+          href="https://twitter.com/simonihmig"
+          class="nav-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <i class="fab fa-twitter"></i>
+        </a>
+      </nav.item>
+      <nav.item class="visible-sm-block visible-xs-block">
+        <a
+          href="https://github.com/kaliber5/ember-bootstrap"
+          class="nav-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <i class="fab fa-github"></i>
+        </a>
+      </nav.item>
+      <nav.item class="hidden-sm hidden-xs">
+        <div class="navbar-text">
+          <iframe
+            src="https://ghbtns.com/github-btn.html?user=kaliber5&repo=ember-bootstrap&type=star&count=true"
+            frameborder="0"
+            scrolling="0"
+            width="100px"
+            height="20px"
+            title="Github Stars"
+          ></iframe>
+        </div>
+      </nav.item>
+    </navbar.nav>
+  </navbar.content>
+</BsNavbar>
 <div class="container mt-4">
   {{outlet}}
 </div>

--- a/docs/app/templates/changelog.hbs
+++ b/docs/app/templates/changelog.hbs
@@ -1,3 +1,3 @@
 <h1>Changelog</h1>
 
-{{markdown-to-html this.model}}
+<MarkdownToHtml @markdown={{this.model}} />

--- a/docs/app/templates/demo/alert.hbs
+++ b/docs/app/templates/demo/alert.hbs
@@ -17,7 +17,7 @@
   Options
 </h2>
 <div class="bs-example">
-  <BsForm @formLayout="inline" @model={{this.this}} as |form|>
+  <BsForm @formLayout="inline" @model={{this}} as |form|>
     <form.element
       @controlType="checkbox"
       @label="Show/Hide"

--- a/docs/app/templates/demo/collapse.hbs
+++ b/docs/app/templates/demo/collapse.hbs
@@ -1,5 +1,5 @@
 <div class="bs-example" data-test-fastboot-container>
-  <BsButton @active={{this.notCollapsed}} @onClick={{action "toggle"}}>
+  <BsButton @active={{this.notCollapsed}} @onClick={{this.toggle}}>
     {{#if this.collapsed}}
       Show
     {{else}}


### PR DESCRIPTION
This resolves a number of linting warnings in the docs app.
It is primarily focused on fixing the `ember/no-classic-classes` lint rule.

There is also a small fix for the rendering of the markdown changelogs, due to `ember-cli-showdown` 8.0.0 removing the ability to use positional parameters.