### PR TITLE
Deprecate `importBootstrapCSS`, remove `importBootstrapTheme` and `importBootstrapFont`

### DIFF
--- a/docs/app/templates/getting-started/assets.hbs
+++ b/docs/app/templates/getting-started/assets.hbs
@@ -28,14 +28,27 @@
 
 <p>
   When not using a CSS preprocessor (see below) you will need to import the
-  static Bootstrap CSS into your ember-cli build:
+  static Bootstrap CSS into yourself.
+</p>
+<p>
+  For classic apps, add the following lines to
+  <code>ember-cli-build.js</code>
+
+  {{! prettier-ignore }}
+  <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, { /* Configuration */ });
+  app.import('node_modules/bootstrap/dist/css/bootstrap.css');
+  app.toTree();
+};</code></pre>
 </p>
 
-<div>
+<p>
+  For Embroider apps, import the CSS file in
+  <code>app/app.js</code>.
   {{! prettier-ignore }}
-  <pre class="highlight"><code>// app/app.js
-import 'bootstrap/dist/css/bootstrap.css';</code></pre>
-</div>
+  <pre class="highlight"><code>import 'bootstrap/dist/css/bootstrap.css';</code></pre>
+</p>
 
 <h2>Using a CSS preprocessor</h2>
 

--- a/docs/app/templates/getting-started/assets.hbs
+++ b/docs/app/templates/getting-started/assets.hbs
@@ -27,21 +27,17 @@
 <h2 id="importing-css-assets">Importing static CSS Assets</h2>
 
 <p>
-  When not using a CSS preprocessor (see below) ember-bootstrap will
-  automatically import the static Bootstrap CSS into your ember-cli build. In
-  situations where you prefer to use another strategy for importing Bootstrap
-  CSS, you can opt out of CSS import by setting the
-  <code>importBootstrapCSS</code>
-  option to false in your
-  <code>ember-cli-build.js</code>:
+  When not using a CSS preprocessor (see below) you will need to import the
+  static Bootstrap CSS into your ember-cli build:
 </p>
 
 <div>
-  <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
-      module.exports = function(defaults) { let app = new EmberApp(defaults, {
-      'ember-bootstrap': { 'importBootstrapCSS': false } }); return
-      app.toTree(); };
-    </code></pre>
+  <pre class="highlight"><code
+      class="language-js"
+    >//your-bootstrap-app/ember-cli-build.js module.exports = function(defaults)
+      { let app = new EmberApp(defaults, { /* Configuration */ });
+      app.import('node_modules/bootstrap/dist/css/bootstrap.css'); app.toTree();
+      };</code></pre>
 </div>
 
 <h2>Using a CSS preprocessor</h2>
@@ -68,8 +64,8 @@
 </p>
 
 <pre class="highlight"><code class="language-sass">// app.scss @import
-    "ember-bootstrap/bootstrap";
-  </code></pre>
+    "node_modules/bootstrap/scss/bootstrap";</code>
+</pre>
 
 <p>This will add the whole bootstrap stylesheets allowing you to customize them
   easily using the available variables.</p>

--- a/docs/app/templates/getting-started/assets.hbs
+++ b/docs/app/templates/getting-started/assets.hbs
@@ -91,18 +91,18 @@ module.exports = function(defaults) {
 {{! prettier-ignore }}
 <pre class="highlight"><code class="language-sass">// app.scss
 // Required
-@import "ember-bootstrap/functions";
-@import "ember-bootstrap/variables";
-@import "ember-bootstrap/mixins";
+@import "node_modules/bootstrap/scss/functions";
+@import "node_modules/bootstrap/scss/variables";
+@import "node_modules/bootstrap/scss/mixins";
 
 // Optional - Bootstrapping/Resetting
-@import "ember-bootstrap/root";
-@import "ember-bootstrap/print";
-@import "ember-bootstrap/reboot";
+@import "node_modules/bootstrap/scss/root";
+@import "node_modules/bootstrap/scss/print"; // Bootstrap 4 only
+@import "node_modules/bootstrap/scss/reboot";
 
 // Optional - Everything else
-@import "ember-bootstrap/type";
-@import "ember-bootstrap/buttons";
+@import "node_modules/bootstrap/scss/type";
+@import "node_modules/bootstrap/scss/buttons";
 </code></pre>
 
 <p>

--- a/docs/app/templates/getting-started/assets.hbs
+++ b/docs/app/templates/getting-started/assets.hbs
@@ -33,12 +33,8 @@
 
 <div>
   {{! prettier-ignore }}
-  <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
-module.exports = function(defaults) {
-  let app = new EmberApp(defaults, { /* Configuration */ });
-  app.import('node_modules/bootstrap/dist/css/bootstrap.css');
-  app.toTree();
-};</code></pre>
+  <pre class="highlight"><code>// app/app.js
+import 'bootstrap/dist/css/bootstrap.css';</code></pre>
 </div>
 
 <h2>Using a CSS preprocessor</h2>

--- a/docs/app/templates/getting-started/assets.hbs
+++ b/docs/app/templates/getting-started/assets.hbs
@@ -32,12 +32,13 @@
 </p>
 
 <div>
-  <pre class="highlight"><code
-      class="language-js"
-    >//your-bootstrap-app/ember-cli-build.js module.exports = function(defaults)
-      { let app = new EmberApp(defaults, { /* Configuration */ });
-      app.import('node_modules/bootstrap/dist/css/bootstrap.css'); app.toTree();
-      };</code></pre>
+  {{! prettier-ignore }}
+  <pre class="highlight"><code>//your-bootstrap-app/ember-cli-build.js
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, { /* Configuration */ });
+  app.import('node_modules/bootstrap/dist/css/bootstrap.css');
+  app.toTree();
+};</code></pre>
 </div>
 
 <h2>Using a CSS preprocessor</h2>
@@ -63,8 +64,9 @@
   file respectively:
 </p>
 
-<pre class="highlight"><code class="language-sass">// app.scss @import
-    "node_modules/bootstrap/scss/bootstrap";</code>
+{{! prettier-ignore }}
+<pre class="highlight"><code class="language-sass">// app.scss
+@import "node_modules/bootstrap/scss/bootstrap";</code>
 </pre>
 
 <p>This will add the whole bootstrap stylesheets allowing you to customize them
@@ -86,13 +88,22 @@
   varies according to the chosen configuration.
 </p>
 
-<pre class="highlight"><code class="language-sass">// app.scss // Required
-    @import "ember-bootstrap/functions"; @import "ember-bootstrap/variables";
-    @import "ember-bootstrap/mixins"; // Optional - Bootstrapping/Resetting
-    @import "ember-bootstrap/root"; @import "ember-bootstrap/print"; @import
-    "ember-bootstrap/reboot"; // Optional - Everything else @import
-    "ember-bootstrap/type"; @import "ember-bootstrap/buttons";
-  </code></pre>
+{{! prettier-ignore }}
+<pre class="highlight"><code class="language-sass">// app.scss
+// Required
+@import "ember-bootstrap/functions";
+@import "ember-bootstrap/variables";
+@import "ember-bootstrap/mixins";
+
+// Optional - Bootstrapping/Resetting
+@import "ember-bootstrap/root";
+@import "ember-bootstrap/print";
+@import "ember-bootstrap/reboot";
+
+// Optional - Everything else
+@import "ember-bootstrap/type";
+@import "ember-bootstrap/buttons";
+</code></pre>
 
 <p>
   You can also checkout which files are available for import in

--- a/docs/app/templates/getting-started/setup.hbs
+++ b/docs/app/templates/getting-started/setup.hbs
@@ -22,9 +22,9 @@
 <p>
   To use ember-bootstrap, you need to include Bootstrap's style sheets into your
   app's build configuration. Add the following line to
-  <code>ember-cli-build.js</code>.
-  <pre class="highlight"><code
-    >app.import('node_modules/bootstrap/dist/css/bootstrap.css');</code></pre>
+  <code>app/app.js</code>.
+  {{! prettier-ignore }}
+  <pre class="highlight"><code>import 'bootstrap/dist/css/bootstrap.css';</code></pre>
 </p>
 
 <h3>Using the default blueprint</h3>

--- a/docs/app/templates/getting-started/setup.hbs
+++ b/docs/app/templates/getting-started/setup.hbs
@@ -17,10 +17,20 @@
 
 <h2>Configuration</h2>
 
+<h3>Using plain css</h3>
+
+<p>
+  To use ember-bootstrap, you need to include Bootstrap's style sheets into your
+  app's build configuration. Add the following line to
+  <code>ember-cli-build.js</code>.
+  <pre class="highlight"><code
+    >app.import('node_modules/bootstrap/dist/css/bootstrap.css');</code></pre>
+</p>
+
 <h3>Using the default blueprint</h3>
 
 <p>
-  By default, ember-bootstrap installs Bootstrap 4 and uses the installed
+  By default, ember-bootstrap installs Bootstrap 5 and uses the installed
   preprocessor if there is one. You can use the ember-bootstrap default
   blueprint to switch the Bootstrap version or preprocessor.
 </p>
@@ -112,7 +122,7 @@
     <tr>
       <td>bootstrapVersion</td>
       <td>4 / 5</td>
-      <td>4</td>
+      <td>5</td>
       <td>
         <p>
           Specify the Bootstrap version to use. To make sure you have the right

--- a/docs/app/templates/getting-started/setup.hbs
+++ b/docs/app/templates/getting-started/setup.hbs
@@ -20,12 +20,34 @@
 <h3>Using plain css</h3>
 
 <p>
-  To use ember-bootstrap, you need to include Bootstrap's style sheets into your
-  app's build configuration. Add the following line to
+  To use ember-bootstrap, include Bootstrap's style sheets into your app's build
+  configuration.
+</p>
+
+<p>
+  For classic apps, add the following to your
+  <code>ember-cli-build.js</code>:
+
+  {{! prettier-ignore }}
+  <pre class="highlight"><code
+>let app = new EmberApp(defaults, { /* Configuration */ });
+app.import('node_modules/bootstrap/dist/css/bootstrap.css');
+app.toTree();
+</code></pre>
+</p>
+
+<p>
+  For apps using Embroider, import the CSS in
   <code>app/app.js</code>.
   {{! prettier-ignore }}
   <pre class="highlight"><code>import 'bootstrap/dist/css/bootstrap.css';</code></pre>
 </p>
+
+See the
+<a
+  href="https://guides.emberjs.com/release/addons-and-dependencies/#toc_css"
+>Ember documentation</a>
+for more information about including assets into your app.
 
 <h3>Using the default blueprint</h3>
 

--- a/ember-bootstrap/blueprints/ember-bootstrap/index.js
+++ b/ember-bootstrap/blueprints/ember-bootstrap/index.js
@@ -117,7 +117,8 @@ module.exports = {
 
   addPreprocessorStyleImport() {
     let preprocessor = this.preprocessor;
-    let importStatement = '\n@import "ember-bootstrap/bootstrap";\n';
+    let importStatement =
+      '\n@import "node_modules/bootstrap/scss/bootstrap";\n';
 
     if (preprocessor === 'none') {
       return;
@@ -148,15 +149,6 @@ module.exports = {
     let settings = {
       bootstrapVersion,
     };
-
-    if (bootstrapVersion === 3) {
-      settings.importBootstrapFont = Object.prototype.hasOwnProperty.call(
-        config,
-        'importBootstrapFont',
-      )
-        ? config.importBootstrapFont
-        : true;
-    }
 
     if (preprocessor !== 'none') {
       settings.importBootstrapCSS = false;

--- a/ember-bootstrap/index.js
+++ b/ember-bootstrap/index.js
@@ -9,9 +9,7 @@ const VersionChecker = require('ember-cli-version-checker');
 const resolve = require('resolve');
 
 const defaultOptions = {
-  importBootstrapTheme: false,
   importBootstrapCSS: true,
-  importBootstrapFont: false,
   insertEmberWormholeElementToDom: true,
   bootstrapVersion: 5,
 };
@@ -69,12 +67,6 @@ module.exports = {
       );
     }
 
-    if (options.bootstrapVersion >= 4 && options.importBootstrapFont) {
-      this.warn(
-        'Inclusion of the Glyphicon font is only supported for Bootstrap 3. ' +
-          "Set Ember Bootstrap's `importBootstrapFont` option to `false` to hide this warning.",
-      );
-    }
     if (process.env.BOOTSTRAPVERSION) {
       // override bootstrapVersion config when environment variable is set
       options.bootstrapVersion = parseInt(process.env.BOOTSTRAPVERSION);
@@ -90,17 +82,17 @@ module.exports = {
     if (!this.hasPreprocessor()) {
       // / Import css from bootstrap
       if (options.importBootstrapCSS) {
+        this.warn(`\
+Importing Bootstrap CSS through Ember Bootstrap is deprecated. Applications should import Bootstrap's CSS explicitly.
+Please find information how to do so in the Ember guides: https://guides.emberjs.com/release/addons-and-dependencies/#toc_css.
+Additionally set importBootstrapCSS configuration of Ember Bootstrap in your app's ember-cli-build.js to false. Please find more information about Ember Bootstrap's configuration here: https://www.ember-bootstrap.com/getting-started/setup
+
+Until: 7.0.0
+`);
+
         this.needsBootstrapStyles = true;
         this.import(path.join(vendorPath, 'bootstrap.css'));
         this.import(path.join(vendorPath, 'bootstrap.css.map'), {
-          destDir: 'assets',
-        });
-      }
-
-      if (options.importBootstrapTheme) {
-        this.needsBootstrapStyles = true;
-        this.import(path.join(vendorPath, 'bootstrap-theme.css'));
-        this.import(path.join(vendorPath, 'bootstrap-theme.css.map'), {
           destDir: 'assets',
         });
       }

--- a/ember-bootstrap/node-tests/blueprints/ember-bootstrap-test.js
+++ b/ember-bootstrap/node-tests/blueprints/ember-bootstrap-test.js
@@ -39,7 +39,7 @@ describe('Acceptance: ember generate ember-bootstrap', function () {
           modifyPackages([{ name: 'ember-cli-sass' }]);
           return emberGenerate(args).then(() => {
             expect(file(`${baseDir}/app.scss`)).to.contain(
-              '@import "ember-bootstrap/bootstrap";',
+              '@import "node_modules/bootstrap/scss/bootstrap";',
             );
             expect(file(`${baseDir}/app.less`)).to.not.exist;
           });
@@ -52,7 +52,7 @@ describe('Acceptance: ember generate ember-bootstrap', function () {
           createStyleFixture('app.scss');
           return emberGenerate(args).then(() => {
             expect(file(`${baseDir}/app.scss`)).to.contain(
-              '@import "ember-bootstrap/bootstrap";',
+              '@import "node_modules/bootstrap/scss/bootstrap";',
             );
             expect(file(`${baseDir}/app.less`)).to.not.exist;
           });
@@ -96,7 +96,7 @@ describe('Acceptance: ember generate ember-bootstrap', function () {
           .then(() => emberGenerate(args))
           .then(() => {
             expect(file('app/styles/app.scss')).to.contain(
-              '@import "ember-bootstrap/bootstrap";',
+              '@import "node_modules/bootstrap/scss/bootstrap";',
             );
             expect(file('app/styles/app.less')).to.not.exist;
           });
@@ -110,7 +110,7 @@ describe('Acceptance: ember generate ember-bootstrap', function () {
           .then(() => emberGenerate(args))
           .then(() => {
             expect(file('app/styles/app.scss')).to.contain(
-              '@import "ember-bootstrap/bootstrap";',
+              '@import "node_modules/bootstrap/scss/bootstrap";',
             );
             expect(file('app/styles/app.less')).to.not.exist;
           });


### PR DESCRIPTION
The CSS and SASS configuration should be manually configured by the consuming addon.
`importBootstrapTheme` and `importBootstrapFont` have been removed instead of deprecated as these only exists for Bootstrap 3, which we do not support.