### PR TITLE
[docs] Resolve remaining lint warnings

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -22,13 +22,6 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {
-    // TODO: Fix all this outdated patterns
-    'ember/no-actions-hash': 'warn',
-    'ember/no-classic-classes': 'warn',
-    'ember/no-get': 'warn',
-    'ember/require-tagless-components': 'warn',
-  },
   overrides: [
     // node files
     {
@@ -57,10 +50,6 @@ module.exports = {
       // test files
       files: ['tests/**/*-test.{js,ts}'],
       extends: ['plugin:qunit/recommended'],
-      rules: {
-        // TODO: Fix this outdated patterns
-        'qunit/no-assert-equal': 'warn',
-      },
     },
   ],
 };

--- a/docs/.template-lintrc.js
+++ b/docs/.template-lintrc.js
@@ -5,15 +5,7 @@ module.exports = {
   extends: ['recommended', 'ember-template-lint-plugin-prettier:recommended'],
   rules: {
     'no-html-comments': false,
-    // TODO: fix all this outdated patterns
-    'no-action': 'warn',
-    'no-autofocus-attribute': 'warn',
-    'no-curly-component-invocation': 'warn',
     'no-implicit-this': { allow: ['current-year'] },
-    'no-invalid-link-text': 'warn',
-    'no-link-to-positional-params': 'warn',
-    'no-valueless-arguments': 'warn',
-    'require-context-role': 'warn',
-    'require-presentational-children': 'warn',
+    'no-curly-component-invocation': { allow: ['current-year'] },
   },
 };

--- a/docs/app/templates/demo/alert.hbs
+++ b/docs/app/templates/demo/alert.hbs
@@ -45,7 +45,7 @@
       class="ml-sm-2"
       as |el|
     >
-      <el.control @searchEnabled @class="ml-1" />
+      <el.control @searchEnabled={{true}} @class="ml-1" />
     </form.element>
     <form.element @label="Header tag" @property="headerTag" class="ml-sm-2" />
   </BsForm>

--- a/docs/app/templates/demo/modal.hbs
+++ b/docs/app/templates/demo/modal.hbs
@@ -43,7 +43,7 @@
     @property="size"
     as |el|
   >
-    <el.control @searchEnabled />
+    <el.control @searchEnabled={{true}} />
   </form.element>
   <form.element
     @controlType="checkbox"
@@ -122,6 +122,9 @@
     <modal.body>
       <label>
         Search:
+        {{! This rule is meant to prevent page loads moving users without warning.
+            As this will only trigger when the modal opens, it should be safe to use here. }}
+        {{! template-lint-disable no-autofocus-attribute }}
         <input type="text" autofocus="autofocus" />
       </label>
     </modal.body>

--- a/docs/app/templates/demo/navbars.hbs
+++ b/docs/app/templates/demo/navbars.hbs
@@ -7,7 +7,7 @@
       @property="type"
       as |el|
     >
-      <el.control @searchEnabled />
+      <el.control @searchEnabled={{true}} />
     </form.element>
     <form.element
       @controlType="power-select"
@@ -16,7 +16,7 @@
       @property="bg"
       as |el|
     >
-      <el.control @searchEnabled />
+      <el.control @searchEnabled={{true}} />
     </form.element>
   </BsForm>
   <hr />

--- a/docs/app/templates/demo/navs.hbs
+++ b/docs/app/templates/demo/navs.hbs
@@ -8,7 +8,7 @@
       @onChange={{this.updateType}}
       as |el|
     >
-      <el.control @searchEnabled @class="ml-sm-1" />
+      <el.control @searchEnabled={{true}} @class="ml-sm-1" />
     </form.element>
     <form.element
       @controlType="checkbox"

--- a/docs/app/templates/demo/popover.hbs
+++ b/docs/app/templates/demo/popover.hbs
@@ -86,7 +86,14 @@
 </BsAlert>
 <div class="bs-example">
   <!-- BEGIN-SNIPPET popover-focus -->
-  <a href="#" role="button" tabindex="0" class="btn btn-primary">
+  {{! Due to the above mentioned rule, this must be an <a> tag.
+      Clicking a <a href="#"> will jump to the top of the page however.
+      By removing it, we get the expected behaviour. }}
+  {{! template-lint-disable link-href-attributes }}
+  {{! The popover is not rendered inside the <a> tag,
+    so it is okay not to have the 'presentational' role. }}
+  {{! template-lint-disable require-presentational-children }}
+  <a role="button" tabindex="0" class="btn btn-primary">
     Focus me
     <BsPopover @triggerEvents="focus" title="Focused">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo magnam

--- a/docs/app/templates/demo/progress.hbs
+++ b/docs/app/templates/demo/progress.hbs
@@ -23,7 +23,7 @@
       @property="type"
       as |el|
     >
-      <el.control @searchEnabled />
+      <el.control @searchEnabled={{true}} />
     </form.element>
     <form.element
       @controlType="checkbox"

--- a/docs/app/templates/demo/tabs.hbs
+++ b/docs/app/templates/demo/tabs.hbs
@@ -122,9 +122,17 @@
 <div class="bs-example">
   <!-- BEGIN-SNIPPET tab-custom -->
   <BsTab @customTabs={{true}} as |tab|>
-    <BsNav @type="tabs" as |nav|>
+    <BsNav
+      aria-owns="tab-custom-pane-1 tab-custom-pane-2"
+      role="tablist"
+      @type="tabs"
+      as |nav|
+    >
       <nav.item>
+        {{! The tab is connected to the nav by the `aria-owns` of the <BsNav> }}
+        {{! template-lint-disable require-context-role }}
         <a
+          id="tab-custom-pane-1"
           href="#pane1"
           class="nav-link {{if (bs-eq tab.activeId 'pane1') 'active'}}"
           role="tab"
@@ -137,7 +145,10 @@
         </a>
       </nav.item>
       <nav.item>
+        {{! The tab is connected to the nav by the `aria-owns` of the <BsNav> }}
+        {{! template-lint-disable require-context-role }}
         <a
+          id="tab-custom-pane-2"
           href="#pane1"
           class="nav-link {{if (bs-eq tab.activeId 'pane2') 'active'}}"
           role="tab"

--- a/docs/app/templates/index.hbs
+++ b/docs/app/templates/index.hbs
@@ -9,7 +9,8 @@
         addon for using
         <a href="http://getbootstrap.com/">Bootstrap</a>
         in
-        <a href="http://www.emberjs.com"></a>Ember.js applications.
+        <a href="http://www.emberjs.com">Ember.js</a>
+        applications.
       </p>
 
       <p>

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,6 @@
     "ember-cli-app-version": "6.0.1",
     "ember-cli-babel": "8.2.0",
     "ember-cli-dependency-checker": "3.3.2",
-    "ember-cli-fastboot": "4.1.2",
     "ember-cli-htmlbars": "6.3.0",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-sass": "11.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "ember-cli-app-version": "6.0.1",
     "ember-cli-babel": "8.2.0",
     "ember-cli-dependency-checker": "3.3.2",
+    "ember-cli-fastboot": "4.1.2",
     "ember-cli-htmlbars": "6.3.0",
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-sass": "11.0.1",

--- a/docs/tests/acceptance/addons-test.js
+++ b/docs/tests/acceptance/addons-test.js
@@ -8,6 +8,6 @@ module('Acceptance | addons', function (hooks) {
   test('visiting /addons', async function (assert) {
     await visit('/addons');
 
-    assert.equal(currentURL(), '/addons');
+    assert.strictEqual(currentURL(), '/addons');
   });
 });

--- a/docs/tests/acceptance/components-test.js
+++ b/docs/tests/acceptance/components-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components', function (hooks) {
   test('visiting /components', async function (assert) {
     await visit('/components');
 
-    assert.equal(currentURL(), '/components');
+    assert.strictEqual(currentURL(), '/components');
   });
 });

--- a/docs/tests/acceptance/components/accordion-test.js
+++ b/docs/tests/acceptance/components/accordion-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/accordion', function (hooks) {
   test('visiting /components/accordion', async function (assert) {
     await visit('/components/accordion');
 
-    assert.equal(currentURL(), '/components/accordion');
+    assert.strictEqual(currentURL(), '/components/accordion');
   });
 });

--- a/docs/tests/acceptance/components/alert-test.js
+++ b/docs/tests/acceptance/components/alert-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/alert', function (hooks) {
   test('visiting /components/alert', async function (assert) {
     await visit('/components/alert');
 
-    assert.equal(currentURL(), '/components/alert');
+    assert.strictEqual(currentURL(), '/components/alert');
   });
 });

--- a/docs/tests/acceptance/components/button-group-test.js
+++ b/docs/tests/acceptance/components/button-group-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/button group', function (hooks) {
   test('visiting /components/button-group', async function (assert) {
     await visit('/components/button-group');
 
-    assert.equal(currentURL(), '/components/button-group');
+    assert.strictEqual(currentURL(), '/components/button-group');
   });
 });

--- a/docs/tests/acceptance/components/button-test.js
+++ b/docs/tests/acceptance/components/button-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/button', function (hooks) {
   test('visiting /components/button', async function (assert) {
     await visit('/components/button');
 
-    assert.equal(currentURL(), '/components/button');
+    assert.strictEqual(currentURL(), '/components/button');
   });
 });

--- a/docs/tests/acceptance/components/carousel-test.js
+++ b/docs/tests/acceptance/components/carousel-test.js
@@ -23,7 +23,7 @@ module('Acceptance | components/carousel', function (hooks) {
 
     // Wait until Ember rendered the UI
     await waitFor('[data-test-option="interval"] input');
-    assert.equal(currentURL(), '/components/carousel');
+    assert.strictEqual(currentURL(), '/components/carousel');
     assert
       .dom('[data-test-example="main"] .carousel-item.active img')
       .hasAttribute('alt', 'First slide', 'shows the first slide');

--- a/docs/tests/acceptance/components/collapse-test.js
+++ b/docs/tests/acceptance/components/collapse-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/collapse', function (hooks) {
   test('visiting /components/collapse', async function (assert) {
     await visit('/components/collapse');
 
-    assert.equal(currentURL(), '/components/collapse');
+    assert.strictEqual(currentURL(), '/components/collapse');
   });
 });

--- a/docs/tests/acceptance/components/dropdown-test.js
+++ b/docs/tests/acceptance/components/dropdown-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/dropdown', function (hooks) {
   test('visiting /components/dropdown', async function (assert) {
     await visit('/components/dropdown');
 
-    assert.equal(currentURL(), '/components/dropdown');
+    assert.strictEqual(currentURL(), '/components/dropdown');
   });
 });

--- a/docs/tests/acceptance/components/forms-test.js
+++ b/docs/tests/acceptance/components/forms-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/forms', function (hooks) {
   test('visiting /components/forms', async function (assert) {
     await visit('/components/forms');
 
-    assert.equal(currentURL(), '/components/forms');
+    assert.strictEqual(currentURL(), '/components/forms');
   });
 });

--- a/docs/tests/acceptance/components/list-group-test.js
+++ b/docs/tests/acceptance/components/list-group-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/list group', function (hooks) {
   test('visiting /components/list-group', async function (assert) {
     await visit('/components/list-group');
 
-    assert.equal(currentURL(), '/components/list-group');
+    assert.strictEqual(currentURL(), '/components/list-group');
   });
 });

--- a/docs/tests/acceptance/components/modal-test.js
+++ b/docs/tests/acceptance/components/modal-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/modal', function (hooks) {
   test('visiting /components/modal', async function (assert) {
     await visit('/components/modal');
 
-    assert.equal(currentURL(), '/components/modal');
+    assert.strictEqual(currentURL(), '/components/modal');
   });
 });

--- a/docs/tests/acceptance/components/navbars-test.js
+++ b/docs/tests/acceptance/components/navbars-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/navbars', function (hooks) {
   test('visiting /components/navbars', async function (assert) {
     await visit('/components/navbars');
 
-    assert.equal(currentURL(), '/components/navbars');
+    assert.strictEqual(currentURL(), '/components/navbars');
   });
 });

--- a/docs/tests/acceptance/components/navs-test.js
+++ b/docs/tests/acceptance/components/navs-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/navs', function (hooks) {
   test('visiting /components/navs', async function (assert) {
     await visit('/components/navs');
 
-    assert.equal(currentURL(), '/components/navs');
+    assert.strictEqual(currentURL(), '/components/navs');
   });
 });

--- a/docs/tests/acceptance/components/popover-test.js
+++ b/docs/tests/acceptance/components/popover-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/popover', function (hooks) {
   test('visiting /components/popover', async function (assert) {
     await visit('/components/popover');
 
-    assert.equal(currentURL(), '/components/popover');
+    assert.strictEqual(currentURL(), '/components/popover');
   });
 });

--- a/docs/tests/acceptance/components/progress-test.js
+++ b/docs/tests/acceptance/components/progress-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/progress', function (hooks) {
   test('visiting /components/progress', async function (assert) {
     await visit('/components/progress');
 
-    assert.equal(currentURL(), '/components/progress');
+    assert.strictEqual(currentURL(), '/components/progress');
   });
 });

--- a/docs/tests/acceptance/components/spinner-test.js
+++ b/docs/tests/acceptance/components/spinner-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/spinner', function (hooks) {
   test('visiting /components/spinner', async function (assert) {
     await visit('/components/spinner');
 
-    assert.equal(currentURL(), '/components/spinner');
+    assert.strictEqual(currentURL(), '/components/spinner');
   });
 });

--- a/docs/tests/acceptance/components/tabs-test.js
+++ b/docs/tests/acceptance/components/tabs-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/tabs', function (hooks) {
   test('visiting /components/tabs', async function (assert) {
     await visit('/components/tabs');
 
-    assert.equal(currentURL(), '/components/tabs');
+    assert.strictEqual(currentURL(), '/components/tabs');
   });
 });

--- a/docs/tests/acceptance/components/tooltip-test.js
+++ b/docs/tests/acceptance/components/tooltip-test.js
@@ -8,6 +8,6 @@ module('Acceptance | components/tooltip', function (hooks) {
   test('visiting /components/tooltip', async function (assert) {
     await visit('/components/tooltip');
 
-    assert.equal(currentURL(), '/components/tooltip');
+    assert.strictEqual(currentURL(), '/components/tooltip');
   });
 });

--- a/docs/tests/acceptance/getting-started-test.js
+++ b/docs/tests/acceptance/getting-started-test.js
@@ -8,6 +8,6 @@ module('Acceptance | getting started', function (hooks) {
   test('visiting /getting-started', async function (assert) {
     await visit('/getting-started');
 
-    assert.equal(currentURL(), '/getting-started');
+    assert.strictEqual(currentURL(), '/getting-started');
   });
 });

--- a/docs/tests/acceptance/getting-started/assets-test.js
+++ b/docs/tests/acceptance/getting-started/assets-test.js
@@ -8,6 +8,6 @@ module('Acceptance | getting started/assets', function (hooks) {
   test('visiting /getting-started/assets', async function (assert) {
     await visit('/getting-started/assets');
 
-    assert.equal(currentURL(), '/getting-started/assets');
+    assert.strictEqual(currentURL(), '/getting-started/assets');
   });
 });

--- a/docs/tests/acceptance/getting-started/setup-test.js
+++ b/docs/tests/acceptance/getting-started/setup-test.js
@@ -8,6 +8,6 @@ module('Acceptance | getting started/setup', function (hooks) {
   test('visiting /getting-started/setup', async function (assert) {
     await visit('/getting-started/setup');
 
-    assert.equal(currentURL(), '/getting-started/setup');
+    assert.strictEqual(currentURL(), '/getting-started/setup');
   });
 });

--- a/docs/tests/acceptance/index-test.js
+++ b/docs/tests/acceptance/index-test.js
@@ -8,6 +8,6 @@ module('Acceptance | index', function (hooks) {
   test('visiting home page', async function (assert) {
     await visit('/');
 
-    assert.equal(currentURL(), '/');
+    assert.strictEqual(currentURL(), '/');
   });
 });


### PR DESCRIPTION
All ESLint and ember-template-lint rules that were set to warn have now been enabled.

There were some remaining places where the lint issue could not be solved, but those places have been annotated with `{{! template-lint-disable }}` and a comment stating the reason for ignoring the lint rules.