### PR TITLE
Run Safari tests after basic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
       - master
       - renovate/*
     tags:
-      - '*'
+      - "*"
   pull_request:
   schedule:
-    - cron: '0 4 * * 5' # Fridays at 4am
+    - cron: "0 4 * * 5" # Fridays at 4am
 
 jobs:
   test:
@@ -26,6 +26,8 @@ jobs:
   test-safari:
     name: Test Safari
     runs-on: macos-latest
+    needs:
+      - test
     steps:
       - name: Checkout code
         uses: wyvox/action@v1


### PR DESCRIPTION
Currently, Safari tests run concurrently to our basic first `test` job, and all other (ember-try) jobs wait on `test`. This makes the Safari test also wait on `test` to pass first, no need to have it run it earlier than all the others.