### PR TITLE
Convert BsLinkTo to TypeScript

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
@@ -14,8 +14,8 @@
       {{yield
         (hash
           item=(ensure-safe-component (bs-default @itemComponent (component "bs-dropdown/menu/item")))
-          link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="dropdown-item")))
-          linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="dropdown-item")))
+          link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="dropdown-item")))
+          linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="dropdown-item")))
           divider=(ensure-safe-component (bs-default @dividerComponent (component "bs-dropdown/menu/divider")))
         )
       }}
@@ -35,8 +35,8 @@
         {{yield
           (hash
             item=(ensure-safe-component (bs-default @itemComponent (component "bs-dropdown/menu/item")))
-            link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="dropdown-item")))
-            linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="dropdown-item")))
+            link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="dropdown-item")))
+            linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="dropdown-item")))
             divider=(ensure-safe-component (bs-default @dividerComponent (component "bs-dropdown/menu/divider")))
           )
         }}

--- a/ember-bootstrap/addon/components/bs-link-to.hbs
+++ b/ember-bootstrap/addon/components/bs-link-to.hbs
@@ -3,6 +3,7 @@
   @models={{this.models}}
   @query={{this.query}}
   @disabled={{@disabled}}
+  class={{@attrClassInternal}}
   ...attributes
 >
   {{yield}}

--- a/ember-bootstrap/addon/components/bs-link-to.hbs
+++ b/ember-bootstrap/addon/components/bs-link-to.hbs
@@ -1,10 +1,8 @@
-{{! @glint-nocheck }}
 <LinkTo
   @route={{@route}}
   @models={{this.models}}
   @query={{this.query}}
   @disabled={{@disabled}}
-  class={{@class}}
   ...attributes
 >
   {{yield}}

--- a/ember-bootstrap/addon/components/bs-link-to.ts
+++ b/ember-bootstrap/addon/components/bs-link-to.ts
@@ -1,6 +1,22 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
+import type RouterService from '@ember/routing/router-service';
+
+export interface BsLinkToSignature {
+  // TODO: Should rely on Element of LinkTo signature instead
+  Element: HTMLAnchorElement;
+  Args: {
+    route?: string;
+    model?: unknown;
+    models?: unknown[];
+    query?: string;
+    disabled?: boolean;
+  };
+  Blocks: {
+    default: [];
+  };
+}
 
 /**
  This is largely copied from Ember.LinkComponent. It is used as extending from Ember.LinkComponent has been deprecated.
@@ -13,9 +29,8 @@ import { assert } from '@ember/debug';
  @extends Component
  @private
 */
-export default class LinkComponent extends Component {
-  @service('router')
-  router;
+export default class LinkComponent extends Component<BsLinkToSignature> {
+  @service declare router: RouterService;
 
   get active() {
     if (!this.args.route) {
@@ -28,7 +43,7 @@ export default class LinkComponent extends Component {
   }
 
   get models() {
-    let { model, models } = this.args;
+    const { model, models } = this.args;
 
     if (model !== undefined) {
       return [model];

--- a/ember-bootstrap/addon/components/bs-link-to.ts
+++ b/ember-bootstrap/addon/components/bs-link-to.ts
@@ -12,6 +12,12 @@ export interface BsLinkToSignature {
     models?: unknown[];
     query?: string;
     disabled?: boolean;
+
+    // private args, for internal use only!
+    /**
+     * @internal
+     */
+    attrClassInternal?: string;
   };
   Blocks: {
     default: [];

--- a/ember-bootstrap/addon/components/bs-nav.hbs
+++ b/ember-bootstrap/addon/components/bs-nav.hbs
@@ -3,8 +3,8 @@
   {{yield
     (hash
       item=(ensure-safe-component (bs-default @itemComponent (component "bs-nav/item")))
-      link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="nav-link")))
-      linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" class="nav-link")))
+      link-to=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="nav-link")))
+      linkTo=(ensure-safe-component (bs-default @linkToComponent (component "bs-link-to" attrClassInternal="nav-link")))
       dropdown=(component (ensure-safe-component (bs-default @dropdownComponent (component "bs-dropdown"))) inNav=true htmlTag="li")
     )
   }}

--- a/ember-bootstrap/addon/components/bs-navbar.hbs
+++ b/ember-bootstrap/addon/components/bs-navbar.hbs
@@ -6,7 +6,7 @@
     content=(component (ensure-safe-component (bs-default @contentComponent (component "bs-navbar/content"))) collapsed=this.collapsed onHidden=this.onCollapsed onShown=this.onExpanded)
     nav=(component
       (ensure-safe-component (bs-default @navComponent (component "bs-navbar/nav")))
-      linkToComponent=(component "bs-navbar/link-to" onCollapse=this.collapse class="nav-link")
+      linkToComponent=(component "bs-navbar/link-to" onCollapse=this.collapse attrClassInternal="nav-link")
     )
     collapse=this.collapse
     expand=this.expand

--- a/ember-bootstrap/addon/components/bs-navbar/link-to.hbs
+++ b/ember-bootstrap/addon/components/bs-navbar/link-to.hbs
@@ -6,7 +6,7 @@
   @query={{@query}}
   @disabled={{@disabled}}
   {{on 'click' this.onClick}}
-  class={{@class}}
+  class={{@attrClassInternal}}
   ...attributes
 >
   {{yield}}


### PR DESCRIPTION
Converts `<BsLinkTo>` to TypeScript.

It seems that we are not having any tests explicitly for `<BsLinkTo>`. It is only implicitly tested due to usage in other components. Therefore this is not touching tests.