### PR TITLE
Fix click events inside `bs-dropdown`s not activating

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown.js
+++ b/ember-bootstrap/addon/components/bs-dropdown.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { getOwnConfig, macroCondition } from '@embroider/macros';
 import { tracked } from '@glimmer/tracking';
+import { next } from '@ember/runloop';
 
 const ESCAPE_KEYCODE = 27; // KeyboardEvent.which value for Escape (Esc) key
 const SPACE_KEYCODE = 32; // KeyboardEvent.which value for space key
@@ -313,7 +314,11 @@ export default class Dropdown extends Component {
   closeDropdown() {
     if (this.args.onHide?.() === false) return;
 
-    this.isOpen = false;
+    // When closing the dropdown immediately, any click event from dropdown items will be discarded.
+    // By deferring the close action to the next render cycle, we ensure that no events get lost.
+    next(this, () => {
+      this.isOpen = false;
+    });
   }
 
   /**

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -23,6 +23,7 @@ module.exports = function (defaults) {
     },
     autoImport: {
       forbidEval: true,
+      watchDependencies: ['ember-bootstrap'],
     },
     trees,
     addons: {


### PR DESCRIPTION
Due to a difference between classic Ember components and Glimmer components, the render timing of the `isOpen` variable of BsDropdown changed. This caused the dropdown to close before a click handler could be activated, which in turn made it impossible to add custom actions to BsDropdown menu items. By deferring the `this.isOpen = false` to the next runloop iteration, the click handler gets the time to fire before the BsDropdown disappears.

Resolves #2098