### PR TITLE
Dropdown should not add .btn-group class

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown.js
+++ b/ember-bootstrap/addon/components/bs-dropdown.js
@@ -232,8 +232,12 @@ export default class Dropdown extends Component {
    */
 
   /**
-   * A computed property to generate the suiting class for the dropdown container, either "dropdown", "dropup" or "btn-group".
-   * BS4 only: "dropleft", "dropright"
+   * A computed property to generate the suiting class for the dropdown container, either
+   *
+   * - "dropdown"
+   * - "dropup"
+   * - "dropstart" (BS5) or "dropleft" (BS4)
+   * - "dropend" (BS5) or "dropright" (BS4)
    *
    * @property containerClass
    * @type string
@@ -241,25 +245,15 @@ export default class Dropdown extends Component {
    * @private
    */
   get containerClass() {
-    let dropDirectionClass = `drop${this.direction}`;
     if (macroCondition(getOwnConfig().isBS5)) {
       if (this.direction === 'left') {
-        dropDirectionClass = 'dropstart';
+        return 'dropstart';
       } else if (this.direction === 'right') {
-        dropDirectionClass = 'dropend';
+        return 'dropend';
       }
     }
-    if (this.hasButton && !this.toggleElement.classList.contains('btn-block')) {
-      return this.direction !== 'down'
-        ? `btn-group ${dropDirectionClass}`
-        : 'btn-group';
-    } else {
-      return dropDirectionClass;
-    }
-  }
 
-  get hasButton() {
-    return this.toggleElement && this.toggleElement.tagName === 'BUTTON';
+    return `drop${this.direction}`;
   }
 
   /**

--- a/test-app/tests/integration/components/bs-dropdown-test.js
+++ b/test-app/tests/integration/components/bs-dropdown-test.js
@@ -50,35 +50,14 @@ module('Integration | Component | bs-dropdown', function (hooks) {
     assert.dom(dropleftClass).exists('has dropleft class');
   });
 
-  test('dropdown container with dropdown button has btn-group class', async function (assert) {
+  test('supports setting btn-group class', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.button>Dropdown
+      hbs`<BsDropdown class='btn-group' as |dd|><dd.button>Dropdown
     <span class='caret'></span></dd.button><dd.menu><li><a
         href='#'
       >Something</a></li></dd.menu></BsDropdown>`,
     );
     assert.dom('.btn-group').exists('has btn-group class');
-  });
-
-  test('dropdown container with block dropdown button has dropdown class', async function (assert) {
-    await render(
-      hbs`<BsDropdown as |dd|><dd.button @block={{true}}>Dropdown
-    <span class='caret'></span></dd.button><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
-    );
-    assert.dom('.dropdown').exists('has dropdown class');
-  });
-
-  test('dropdown container with dropdown button supports dropup style', async function (assert) {
-    await render(
-      hbs`<BsDropdown @direction='up' as |dd|><dd.button>Dropdown
-    <span class='caret'></span></dd.button><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
-    );
-    assert.dom('.btn-group').exists('has btn-group class');
-    assert.dom('.dropup').exists('has dropup class');
   });
 
   test('dropdown-toggle toggles dropdown visibility', async function (assert) {


### PR DESCRIPTION
`<BsDropdown>` used the `.btn-group` in some cases on the wrapping `<div>` element. But this should be fully controlled by the consumer.

Per Bootstrap docs:

> Wrap the dropdown’s toggle (your button or link) and the dropdown menu within `.dropdown`, or another element that declares `position: relative;`.
>
> https://getbootstrap.com/docs/5.3/components/dropdowns/#examples and https://getbootstrap.com/docs/4.6/components/dropdowns/#examples

Having the `.dropdown` class always fulfills the requirement, while consumer can add `.btn-group` or similar classes _additionally_.

The `.btn-group` class was added if

1. a `<button>` element was used as toggle and
2. the `<button>` was _not_ rendered in block mode.

This seems to be a leftover from BS3 support. For BS3 a `.btn-group` was required in this case:

> Use any button to trigger a dropdown menu by placing it within a `.btn-group` and providing the proper menu markup.
>
> https://getbootstrap.com/docs/3.4/components/#btn-dropdowns

I run into it when refactoring how `<BsDropdown::Button>` extends `<BsButton>` as preparation work for #2109.

This change _may_ break some apps, which rely on Ember Bootstrap adding the `.btn-group` class in that case. Not sure how likely it is that an app relies on 1) the difference between `.dropdown` and `.btn-group` _and_ 2) Ember Bootstrap adding the `.btn-group` class implicitly. I feel we should consider it a bug fix as Ember Bootstrap does not render the _expected_ markup for BS4 and BS5.