### PR TITLE
Drop unused argument @ariaRole from <BsDropdown::Menu>

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown/menu.js
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.js
@@ -24,16 +24,6 @@ export default class DropdownMenu extends Component {
   @ref('menuElement') menuElement = null;
 
   /**
-   * @property ariaRole
-   * @default menu
-   * @type string
-   * @protected
-   */
-  get ariaRole() {
-    return this.args.ariaRole ?? 'menu';
-  }
-
-  /**
    * Alignment of the menu, either "left" or "right"
    *
    * @property align


### PR DESCRIPTION
The `@ariaRole` argument was required for BS3. It is not used anymore since https://github.com/ember-bootstrap/ember-bootstrap/commit/8bc57449335dd39c759e9b14372555382401f5c5#diff-5f64d3b3af0f75bb6cb845fecfc7dff2583cdbc9b8fc9a54abb456ff4e498a41L39. 

I noticed it when typing the component. It seems that the TypeScript already pays off by uncovering old leftovers. :smile: 

I feel #2109 will get huge. Therefore trying to pull out as many small changes as possible and landing them before.

As the argument did not had any effect, I think we can consider it an internal change.