### PR TITLE
Fix tooltip offset when using Bootstrap > 5.3

### DIFF
--- a/ember-bootstrap/addon/components/bs-tooltip/element.js
+++ b/ember-bootstrap/addon/components/bs-tooltip/element.js
@@ -12,4 +12,5 @@ import { getOwnConfig, macroCondition } from '@embroider/macros';
 export default class TooltipElement extends ContextualHelpElement {
   arrowClass = macroCondition(getOwnConfig().isBS4) ? 'arrow' : 'tooltip-arrow';
   placementClassPrefix = 'bs-tooltip-';
+  offset = [0, 6];
 }

--- a/test-app/tests/integration/components/bs-tooltip-test.js
+++ b/test-app/tests/integration/components/bs-tooltip-test.js
@@ -387,7 +387,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     setupForPositioning();
 
     await triggerEvent('#target', 'mouseenter');
-    assertPositioning(assert);
+    assertPositioning(assert, '.tooltip', 6);
   });
 
   test('should place tooltip on top of element if already visible', async function (assert) {
@@ -410,7 +410,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     setupForPositioning();
     this.set('visible', true);
     await settled();
-    assertPositioning(assert);
+    assertPositioning(assert, '.tooltip', 6);
   });
 
   test('should place tooltip on top of element if visible is set to true', async function (assert) {
@@ -433,7 +433,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
     this.set('visible', true);
     await settled();
-    assertPositioning(assert);
+    assertPositioning(assert, '.tooltip', 6);
   });
 
   test("should show tooltip if leave event hasn't occurred before delay expires", async function (assert) {
@@ -630,7 +630,7 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     await delay(50);
 
     assert.dom('.tooltip').hasClass(tooltipPositionClass('top'));
-    assertPositioning(assert);
+    assertPositioning(assert, '.tooltip', 6);
   });
 
   test('it yields close action', async function (assert) {


### PR DESCRIPTION
The caused by this upstream change: https://github.com/twbs/bootstrap/commit/d533e6f33de2a26a0b7bf5a577eb5c120e51face

The fix causes tooltips to be slightly positioned wrong for Bootstrap >= 5 and < 5.3. We decided to accept that trade-off. React Bootstrap has done the same: https://github.com/react-bootstrap/react-bootstrap/pull/6622

Shoutout to @cybrox for bringing this issue to our attention and helping investigate!