### PR TITLE
Fix alignment of dropdown menus when using Bootstrap 5

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
@@ -2,6 +2,7 @@
 {{#if @isOpen}}
   {{#if this._renderInPlace}}
     <div
+      data-bs-popper
       class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}}"
       tabindex="-1"
       ...attributes
@@ -23,6 +24,7 @@
   {{else}}
     {{#in-element this.destinationElement insertBefore=null}}
       <div
+        data-bs-popper
         class="dropdown-menu {{this.alignClass}} {{if this.isOpen "show"}}"
         tabindex="-1"
         ...attributes

--- a/ember-bootstrap/addon/components/bs-dropdown/menu.js
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.js
@@ -90,18 +90,12 @@ export default class DropdownMenu extends Component {
   }
 
   get alignClass() {
-    if (macroCondition(getOwnConfig().isBS4)) {
-      return this.align !== 'left' ? `dropdown-menu-${this.align}` : undefined;
+    if (this.align === 'right') {
+      const alignClass = macroCondition(getOwnConfig().isBS4) ? 'right' : 'end';
+      return `dropdown-menu-${alignClass}`;
     }
 
-    switch (this.align) {
-      case 'left':
-        return 'dropdown-menu-start';
-      case 'right':
-        return 'dropdown-menu-end';
-      default:
-        return undefined;
-    }
+    return undefined;
   }
 
   @tracked

--- a/ember-bootstrap/addon/components/bs-dropdown/menu.js
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.js
@@ -4,6 +4,7 @@ import { next } from '@ember/runloop';
 import { getDestinationElement } from 'ember-bootstrap/utils/dom';
 import { ref } from 'ember-ref-bucket';
 import { tracked } from '@glimmer/tracking';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 
 /**
  Component for the dropdown menu.
@@ -32,7 +33,7 @@ export default class DropdownMenu extends Component {
    * @public
    */
   get align() {
-    return this.args.align ?? 'false';
+    return this.args.align ?? 'left';
   }
 
   /**
@@ -89,7 +90,18 @@ export default class DropdownMenu extends Component {
   }
 
   get alignClass() {
-    return this.align !== 'left' ? `dropdown-menu-${this.align}` : undefined;
+    if (macroCondition(getOwnConfig().isBS4)) {
+      return this.align !== 'left' ? `dropdown-menu-${this.align}` : undefined;
+    }
+
+    switch (this.align) {
+      case 'left':
+        return 'dropdown-menu-start';
+      case 'right':
+        return 'dropdown-menu-end';
+      default:
+        return undefined;
+    }
   }
 
   @tracked

--- a/test-app/tests/integration/components/bs-dropdown/menu-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | bs-dropdown/menu', function (hooks) {
     assert.dom('.dropdown-menu').hasText('Something');
   });
 
-  test('dropdown has correct class for @align="left"', async function (assert) {
+  test('dropdown has no align class for @align="left"', async function (assert) {
     await render(
       hbs`<BsDropdown as |dd|><dd.menu
     @align='left'
@@ -44,13 +44,8 @@ module('Integration | Component | bs-dropdown/menu', function (hooks) {
   >Something</dd.menu></BsDropdown>`,
     );
 
-    let alignmentClass = versionDependent(
-      'dropdown-menu-left',
-      'dropdown-menu-start',
-    );
-    assert
-      .dom('.dropdown-menu')
-      .hasClass(alignmentClass, `menu has ${alignmentClass} class`);
+    const element = document.querySelector('.dropdown-menu');
+    assert.deepEqual([...element.classList], ['dropdown-menu', 'show']);
   });
 
   test('dropdown menu yields item component', async function (assert) {

--- a/test-app/tests/integration/components/bs-dropdown/menu-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu-test.js
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
+import { versionDependent } from '../../../helpers/bootstrap';
 
 module('Integration | Component | bs-dropdown/menu', function (hooks) {
   setupRenderingTest(hooks);
@@ -18,6 +19,10 @@ module('Integration | Component | bs-dropdown/menu', function (hooks) {
   >Something</dd.menu></BsDropdown>`,
     );
 
+    let alignmentClass = versionDependent(
+      'dropdown-menu-right',
+      'dropdown-menu-end',
+    );
     assert.equal(
       this.element.querySelector('.dropdown-menu').tagName,
       'DIV',
@@ -26,8 +31,26 @@ module('Integration | Component | bs-dropdown/menu', function (hooks) {
     assert.dom('.dropdown-menu').exists('menu has dropdown-menu class');
     assert
       .dom('.dropdown-menu')
-      .hasClass('dropdown-menu-right', 'menu has dropdown-menu-right class');
+      .hasClass(alignmentClass, `menu has ${alignmentClass} class`);
     assert.dom('.dropdown-menu').hasText('Something');
+  });
+
+  test('dropdown has correct class for @align="left"', async function (assert) {
+    await render(
+      hbs`<BsDropdown as |dd|><dd.menu
+    @align='left'
+    @isOpen={{true}}
+    @toggleElement={{this.element}}
+  >Something</dd.menu></BsDropdown>`,
+    );
+
+    let alignmentClass = versionDependent(
+      'dropdown-menu-left',
+      'dropdown-menu-start',
+    );
+    assert
+      .dom('.dropdown-menu')
+      .hasClass(alignmentClass, `menu has ${alignmentClass} class`);
   });
 
   test('dropdown menu yields item component', async function (assert) {


### PR DESCRIPTION
Bootstrap 5 uses start/end instead of left/right. The menu was still using the value from the align argument. In addition to this, the styles used in Bootstrap 5 check for the existence of the [data-bs-popper] attribute. This has been added to the menu as well.

I noticed this issue while converting the app at work from BS4 to BS5.

Before fix: 
![image](https://github.com/ember-bootstrap/ember-bootstrap/assets/7213734/0a69851b-ba4a-4991-9651-6256c868a75d)


After fix:
![image](https://github.com/ember-bootstrap/ember-bootstrap/assets/7213734/b129a729-2728-4992-a17a-9a11301799c0)
