### PR TITLE
modernize hbs import in tests

### DIFF
--- a/test-app/tests/integration/components/bs-accordion-test.js
+++ b/test-app/tests/integration/components/bs-accordion-test.js
@@ -1,7 +1,7 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import {
   accordionClass,
   accordionItemClass,

--- a/test-app/tests/integration/components/bs-accordion/item-test.js
+++ b/test-app/tests/integration/components/bs-accordion/item-test.js
@@ -1,7 +1,7 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import {
   accordionClassFor,
   accordionItemBodyClass,

--- a/test-app/tests/integration/components/bs-alert-test.js
+++ b/test-app/tests/integration/components/bs-alert-test.js
@@ -6,7 +6,7 @@ import {
   test,
   testRequiringTransitions,
 } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/bs-button-group-test.js
+++ b/test-app/tests/integration/components/bs-button-group-test.js
@@ -2,7 +2,7 @@ import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import { testBS5, testForBootstrap } from '../../helpers/bootstrap';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';

--- a/test-app/tests/integration/components/bs-carousel-test.js
+++ b/test-app/tests/integration/components/bs-carousel-test.js
@@ -1,4 +1,4 @@
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { module, skip } from 'qunit';
 import {
   click,

--- a/test-app/tests/integration/components/bs-dropdown-test.js
+++ b/test-app/tests/integration/components/bs-dropdown-test.js
@@ -9,7 +9,7 @@ import {
   test,
   versionDependent,
 } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/bs-dropdown/button-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/button-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-dropdown/button', function (hooks) {

--- a/test-app/tests/integration/components/bs-dropdown/menu-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu-test.js
@@ -1,7 +1,7 @@
 import { module, skip, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import { gte } from 'ember-compatibility-helpers';
 import { versionDependent } from '../../../helpers/bootstrap';

--- a/test-app/tests/integration/components/bs-dropdown/menu/divider-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu/divider-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-dropdown/menu/divider', function (hooks) {

--- a/test-app/tests/integration/components/bs-dropdown/menu/item-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu/item-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-dropdown/menu/item', function (hooks) {

--- a/test-app/tests/integration/components/bs-dropdown/menu/link-to-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/menu/link-to-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-dropdown/menu/link-to', function (hooks) {

--- a/test-app/tests/integration/components/bs-dropdown/toggle-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/toggle-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
 

--- a/test-app/tests/integration/components/bs-form-test.js
+++ b/test-app/tests/integration/components/bs-form-test.js
@@ -25,7 +25,7 @@ import {
   validationSuccessClass,
 } from '../../helpers/bootstrap';
 import { defer } from '../../helpers/defer';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { next, run } from '@ember/runloop';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';

--- a/test-app/tests/integration/components/bs-form/element-test.js
+++ b/test-app/tests/integration/components/bs-form/element-test.js
@@ -26,7 +26,7 @@ import {
   validationWarningClass,
   visuallyHiddenClass,
 } from '../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
 import { tracked } from '@glimmer/tracking';

--- a/test-app/tests/integration/components/bs-form/element/control/checkbox-test.js
+++ b/test-app/tests/integration/components/bs-form/element/control/checkbox-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../../helpers/setup-no-deprecations';
 
 module(

--- a/test-app/tests/integration/components/bs-form/element/control/input-test.js
+++ b/test-app/tests/integration/components/bs-form/element/control/input-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../../helpers/setup-no-deprecations';
 
 module(

--- a/test-app/tests/integration/components/bs-form/element/control/switch-test.js
+++ b/test-app/tests/integration/components/bs-form/element/control/switch-test.js
@@ -2,7 +2,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { testBS4, testBS5 } from '../../../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../../helpers/setup-no-deprecations';
 
 module(

--- a/test-app/tests/integration/components/bs-form/element/control/textarea-test.js
+++ b/test-app/tests/integration/components/bs-form/element/control/textarea-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../../helpers/setup-no-deprecations';
 
 module(

--- a/test-app/tests/integration/components/bs-form/element/errors-test.js
+++ b/test-app/tests/integration/components/bs-form/element/errors-test.js
@@ -3,7 +3,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { formFeedbackClass, test } from '../../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs form/element/errors', function (hooks) {

--- a/test-app/tests/integration/components/bs-form/element/feedback-icon-test.js
+++ b/test-app/tests/integration/components/bs-form/element/feedback-icon-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module(

--- a/test-app/tests/integration/components/bs-form/element/help-text-test.js
+++ b/test-app/tests/integration/components/bs-form/element/help-text-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { formHelpTextClass } from '../../../../helpers/bootstrap';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 

--- a/test-app/tests/integration/components/bs-form/element/label-test.js
+++ b/test-app/tests/integration/components/bs-form/element/label-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { testBS4, testBS5 } from '../../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs form/element/label', function (hooks) {

--- a/test-app/tests/integration/components/bs-modal-simple-test.js
+++ b/test-app/tests/integration/components/bs-modal-simple-test.js
@@ -17,7 +17,7 @@ import {
   testRequiringTransitions,
   visibilityClass,
 } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/bs-modal-test.js
+++ b/test-app/tests/integration/components/bs-modal-test.js
@@ -11,7 +11,7 @@ import {
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import { test, testBS5, visibilityClass } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
 import { skipTransition } from 'ember-bootstrap/utils/transition-end';

--- a/test-app/tests/integration/components/bs-modal/footer-test.js
+++ b/test-app/tests/integration/components/bs-modal/footer-test.js
@@ -2,7 +2,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { defaultButtonClass, test } from '../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-modal/footer', function (hooks) {

--- a/test-app/tests/integration/components/bs-modal/header-test.js
+++ b/test-app/tests/integration/components/bs-modal/header-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import { closeButtonClass, versionDependent } from '../../../helpers/bootstrap';
 

--- a/test-app/tests/integration/components/bs-nav-test.js
+++ b/test-app/tests/integration/components/bs-nav-test.js
@@ -2,7 +2,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { test } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 

--- a/test-app/tests/integration/components/bs-nav/item-test.js
+++ b/test-app/tests/integration/components/bs-nav/item-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
 

--- a/test-app/tests/integration/components/bs-nav/link-to-test.js
+++ b/test-app/tests/integration/components/bs-nav/link-to-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-nav/link-to', function (hooks) {

--- a/test-app/tests/integration/components/bs-navbar-test.js
+++ b/test-app/tests/integration/components/bs-navbar-test.js
@@ -9,7 +9,7 @@ import {
   testBS5,
   visibilityClass,
 } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/bs-navbar/content-test.js
+++ b/test-app/tests/integration/components/bs-navbar/content-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-navbar/content', function (hooks) {

--- a/test-app/tests/integration/components/bs-navbar/nav-test.js
+++ b/test-app/tests/integration/components/bs-navbar/nav-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-navbar/nav', function (hooks) {

--- a/test-app/tests/integration/components/bs-navbar/toggle-test.js
+++ b/test-app/tests/integration/components/bs-navbar/toggle-test.js
@@ -2,7 +2,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { test, versionDependent } from '../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-navbar/toggle', function (hooks) {

--- a/test-app/tests/integration/components/bs-popover-test.js
+++ b/test-app/tests/integration/components/bs-popover-test.js
@@ -1,7 +1,7 @@
 import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render, settled, triggerEvent } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import {
   popoverArrowClass,
   popoverPositionClass,

--- a/test-app/tests/integration/components/bs-progress-test.js
+++ b/test-app/tests/integration/components/bs-progress-test.js
@@ -2,7 +2,7 @@ import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { test, visuallyHiddenClass } from '../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';

--- a/test-app/tests/integration/components/bs-tab-test.js
+++ b/test-app/tests/integration/components/bs-tab-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render, settled } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';

--- a/test-app/tests/integration/components/bs-tab/pane-test.js
+++ b/test-app/tests/integration/components/bs-tab/pane-test.js
@@ -6,7 +6,7 @@ import {
   testRequiringTransitions,
   visibilityClass,
 } from '../../../helpers/bootstrap';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 
 module('Integration | Component | bs-tab/pane', function (hooks) {

--- a/test-app/tests/integration/components/bs-tooltip-test.js
+++ b/test-app/tests/integration/components/bs-tooltip-test.js
@@ -9,7 +9,7 @@ import {
   triggerEvent,
   waitUntil,
 } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import {
   delay,
   test,


### PR DESCRIPTION
Importing `hbs` from `htmlbars-inline-precompile-template` is an outdated pattern. And it does not support TypeScript. This PR modernizes all imports at once to TypeScript conversion and lower the barrier of entrance.