### PR TITLE
Add @ to `onClick` in BsModal::Footer submit button

### DIFF
--- a/ember-bootstrap/addon/components/bs-modal/footer.hbs
+++ b/ember-bootstrap/addon/components/bs-modal/footer.hbs
@@ -6,7 +6,13 @@
     {{else}}
       {{#if @submitTitle}}
         <Button @onClick={{@onClose}}>{{bs-default @closeTitle "Ok"}}</Button>
-        <Button @type={{bs-default @submitButtonType "primary"}} @onClick={{@onSubmit}} disabled={{bs-default @submitDisabled false}}>{{@submitTitle}}</Button>
+        <Button
+          @type={{bs-default @submitButtonType "primary"}}
+          @onClick={{@onSubmit}}
+          {{bs-conditional-attribute "disabled" @submitDisabled @submitDisabled}}
+        >
+          {{@submitTitle}}
+        </Button>
       {{else}}
         <Button @type="primary" @onClick={{@onClose}}>{{bs-default @closeTitle "Ok"}}</Button>
       {{/if}}

--- a/ember-bootstrap/addon/components/bs-modal/footer.hbs
+++ b/ember-bootstrap/addon/components/bs-modal/footer.hbs
@@ -6,7 +6,7 @@
     {{else}}
       {{#if @submitTitle}}
         <Button @onClick={{@onClose}}>{{bs-default @closeTitle "Ok"}}</Button>
-        <Button @type={{bs-default @submitButtonType "primary"}} onClick={{@onSubmit}} disabled={{bs-default @submitDisabled false}}>{{@submitTitle}}</Button>
+        <Button @type={{bs-default @submitButtonType "primary"}} @onClick={{@onSubmit}} disabled={{bs-default @submitDisabled false}}>{{@submitTitle}}</Button>
       {{else}}
         <Button @type="primary" @onClick={{@onClose}}>{{bs-default @closeTitle "Ok"}}</Button>
       {{/if}}

--- a/ember-bootstrap/addon/modifiers/bs-conditional-attribute.ts
+++ b/ember-bootstrap/addon/modifiers/bs-conditional-attribute.ts
@@ -1,0 +1,21 @@
+import { modifier } from 'ember-modifier';
+
+interface Signature {
+  Args: {
+    Positional: [attribute: string, condition: boolean, value: string];
+  };
+  Element: HTMLElement;
+}
+
+export default modifier<Signature>(
+  (
+    element: HTMLElement,
+    [attribute, condition, value]: Signature['Args']['Positional'],
+  ) => {
+    if (condition) {
+      element.setAttribute(attribute, value);
+    } else {
+      element.removeAttribute(attribute);
+    }
+  },
+);

--- a/ember-bootstrap/app/modifiers/bs-conditional-attribute.js
+++ b/ember-bootstrap/app/modifiers/bs-conditional-attribute.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-bootstrap/modifiers/bs-conditional-attribute';

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -54,7 +54,7 @@
     "ember-concurrency": "^2.1.2 || ^3.0.0",
     "ember-element-helper": "^0.6.0 || ^0.7.0 || ^0.8.0",
     "ember-focus-trap": "^1.0.0",
-    "ember-modifier": "^4.1.0",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "ember-on-helper": "^0.1.0",
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -54,7 +54,6 @@
     "ember-concurrency": "^2.1.2 || ^3.0.0",
     "ember-element-helper": "^0.6.0 || ^0.7.0 || ^0.8.0",
     "ember-focus-trap": "^1.0.0",
-    "ember-modifier": "^3.2.7 || ^4.0.0",
     "ember-on-helper": "^0.1.0",
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",
@@ -99,7 +98,8 @@
   "peerDependencies": {
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "ember-source": ">=4.8.0"
+    "ember-source": ">=4.8.0",
+    "ember-modifier": "^3.2.7 || ^4.0.0"
   },
   "engines": {
     "node": "18.* || >= 20"

--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -54,6 +54,7 @@
     "ember-concurrency": "^2.1.2 || ^3.0.0",
     "ember-element-helper": "^0.6.0 || ^0.7.0 || ^0.8.0",
     "ember-focus-trap": "^1.0.0",
+    "ember-modifier": "^4.1.0",
     "ember-on-helper": "^0.1.0",
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",

--- a/ember-bootstrap/types/glint.d.ts
+++ b/ember-bootstrap/types/glint.d.ts
@@ -6,6 +6,7 @@ import type RenderModifiersRegistry from '@ember/render-modifiers/template-regis
 import type EmberStyleModifierRegistry from 'ember-style-modifier/template-registry';
 import type sizeClassHelper from 'ember-bootstrap/helpers/bs-size-class';
 import type typeClassHelper from 'ember-bootstrap/helpers/bs-type-class';
+import type BsConditionalAttribute from 'ember-bootstrap/modifiers/bs-conditional-attribute';
 
 import type { HelperLike } from '@glint/template';
 import type { EmberBootstrapMacrosConfig } from './macros-config';
@@ -24,6 +25,7 @@ declare module '@glint/environment-ember-loose/registry' {
       RenderModifiersRegistry {
     'bs-size-class': typeof sizeClassHelper;
     'bs-type-class': typeof typeClassHelper;
+    'bs-conditional-attribute': typeof BsConditionalAttribute;
 
     macroGetOwnConfig: macroGetOwnConfig;
     macroCondition: EmbroiderMacrosRegistry['macroCondition'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       ember-focus-trap:
         specifier: ^1.0.0
         version: 1.1.0(ember-source@5.7.0)
+      ember-modifier:
+        specifier: ^4.1.0
+        version: 4.1.0(ember-source@5.7.0)
       ember-on-helper:
         specifier: ^0.1.0
         version: 0.1.0
@@ -317,7 +320,7 @@ importers:
         version: 1.3.0(typescript@5.4.2)
       '@glint/environment-ember-loose':
         specifier: 1.3.0
-        version: 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)
+        version: 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -431,7 +434,7 @@ importers:
         version: 1.3.0(typescript@5.4.2)
       '@glint/environment-ember-loose':
         specifier: 1.3.0
-        version: 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)
+        version: 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -2172,7 +2175,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@embroider/macros': 1.15.0(@glint/template@1.3.0)
-      '@glint/environment-ember-loose': 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)
+      '@glint/environment-ember-loose': 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@glint/template': 1.3.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 8.2.0(@babel/core@7.24.0)
@@ -2513,7 +2516,7 @@ packages:
       - supports-color
     dev: true
 
-  /@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0):
+  /@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0):
     resolution: {integrity: sha512-kURIttax2zG1oYniJ4bd3rhJRuP588Ld4YAG5EFzjg4s01oLQKpfNskxwSwox07PUkygm2D+9v3Foo2TlYJSSg==}
     peerDependencies:
       '@glimmer/component': ^1.1.2
@@ -2544,6 +2547,7 @@ packages:
       '@glimmer/component': 1.1.2(@babel/core@7.24.0)
       '@glint/template': 1.3.0
       ember-cli-htmlbars: 6.3.0
+      ember-modifier: 4.1.0(ember-source@5.7.0)
 
   /@glint/template@1.3.0:
     resolution: {integrity: sha512-FUfbXSyh+KnwUaMTG4skESPPYL6trwAIKOp9yMwDo+Uw4LxCJjQ9/RCAJTTXZ0/kiTHLr7S2P4vsIbHeorOvaA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,7 +273,7 @@ importers:
         specifier: ^1.0.0
         version: 1.1.0(ember-source@5.7.0)
       ember-modifier:
-        specifier: ^4.1.0
+        specifier: ^3.2.7 || ^4.0.0
         version: 4.1.0(ember-source@5.7.0)
       ember-on-helper:
         specifier: ^0.1.0

--- a/test-app/tests/integration/components/bs-modal/footer-test.js
+++ b/test-app/tests/integration/components/bs-modal/footer-test.js
@@ -1,9 +1,10 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click, render, settled } from '@ember/test-helpers';
 import { defaultButtonClass, test } from '../../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
+import { defer } from '../../../helpers/defer';
 import { stub } from 'sinon';
 
 module('Integration | Component | bs-modal/footer', function (hooks) {
@@ -77,6 +78,31 @@ module('Integration | Component | bs-modal/footer', function (hooks) {
     assert
       .dom('.modal-footer button:last-child')
       .hasText('submit', 'Submit button title is correct.');
+    assert.strictEqual(submit.callCount, 1, '@onSubmit is called exactly once');
+  });
+
+  test('Footer submit button gets disabled when `onSubmit` returns a pending promise', async function (assert) {
+    const { promise, resolve } = defer();
+    const submit = this.set('submit', stub().returns(promise));
+
+    await render(
+      hbs`<BsModal::Footer
+  @onSubmit={{this.submit}}
+  @closeTitle='close'
+  @submitTitle='submit'
+/>`,
+    );
+    await click('.modal-footer button:last-child');
+    assert
+      .dom('.modal-footer button:last-child')
+      .isDisabled('Submit button is disabled');
+
+    resolve();
+    await settled();
+    assert
+      .dom('.modal-footer button:last-child')
+      .isNotDisabled('Submit button is active');
+
     assert.strictEqual(submit.callCount, 1, '@onSubmit is called exactly once');
   });
 

--- a/test-app/tests/integration/components/bs-modal/footer-test.js
+++ b/test-app/tests/integration/components/bs-modal/footer-test.js
@@ -1,16 +1,22 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { defaultButtonClass, test } from '../../../helpers/bootstrap';
 import hbs from 'htmlbars-inline-precompile';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
+import { stub } from 'sinon';
 
 module('Integration | Component | bs-modal/footer', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 
   test('Footer has close button', async function (assert) {
-    await render(hbs`<BsModal::Footer @closeTitle='close' />`);
+    const close = this.set('close', stub());
+
+    await render(
+      hbs`<BsModal::Footer @onClose={{this.close}} @closeTitle='close' />`,
+    );
+    await click('.modal-footer button');
 
     assert.dom('.modal-footer').exists({ count: 1 }, 'Modal footer exists.');
     assert
@@ -27,12 +33,16 @@ module('Integration | Component | bs-modal/footer', function (hooks) {
     assert
       .dom('.modal-footer button')
       .hasText('close', 'Button title is correct.');
+    assert.strictEqual(close.callCount, 1, '@onClose is called exactly once');
   });
 
   test('Footer can have submit button', async function (assert) {
+    const submit = this.set('submit', stub());
+
     await render(
-      hbs`<BsModal::Footer @closeTitle='close' @submitTitle='submit' />`,
+      hbs`<BsModal::Footer @onSubmit={{this.submit}} @closeTitle='close' @submitTitle='submit'/>`,
     );
+    await click('.modal-footer button:last-child');
 
     assert
       .dom('.modal-footer button')
@@ -63,6 +73,7 @@ module('Integration | Component | bs-modal/footer', function (hooks) {
     assert
       .dom('.modal-footer button:last-child')
       .hasText('submit', 'Submit button title is correct.');
+    assert.strictEqual(submit.callCount, 1, '@onSubmit is called exactly once');
   });
 
   test('Footer can have a custom submitButtonType', async function (assert) {

--- a/test-app/tests/integration/components/bs-modal/footer-test.js
+++ b/test-app/tests/integration/components/bs-modal/footer-test.js
@@ -40,7 +40,11 @@ module('Integration | Component | bs-modal/footer', function (hooks) {
     const submit = this.set('submit', stub());
 
     await render(
-      hbs`<BsModal::Footer @onSubmit={{this.submit}} @closeTitle='close' @submitTitle='submit'/>`,
+      hbs`<BsModal::Footer
+  @onSubmit={{this.submit}}
+  @closeTitle='close'
+  @submitTitle='submit'
+/>`,
     );
     await click('.modal-footer button:last-child');
 

--- a/test-app/tests/integration/modifiers/bs-conditional-attribute-test.ts
+++ b/test-app/tests/integration/modifiers/bs-conditional-attribute-test.ts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | bs-conditional-attribute', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it adds the attribute when condition argument is `true`', async function (assert) {
+    await render(
+      hbs`<button type='button' {{bs-conditional-attribute 'disabled' true 'true'}} />`,
+    );
+    assert.dom('button').hasAttribute('disabled');
+
+    await render(
+      hbs`<button type='button' {{bs-conditional-attribute 'disabled' true ''}} />`,
+    );
+    assert.dom('button').hasAttribute('disabled');
+  });
+
+  test('it does not add the attribute when condition argument is `false`', async function (assert) {
+    await render(
+      hbs`<button type='button' {{bs-conditional-attribute 'disabled' false 'true'}} />`,
+    );
+    assert.dom('button').doesNotHaveAttribute('disabled');
+    assert.dom('button').isNotDisabled('disabled');
+  });
+});

--- a/test-app/types/glint.d.ts
+++ b/test-app/types/glint.d.ts
@@ -1,7 +1,10 @@
 import '@glint/environment-ember-loose';
 
 import type EmberBootstrapRegistry from 'ember-bootstrap/template-registry';
+import type BsConditionalAttribute from 'ember-bootstrap/modifiers/bs-conditional-attribute';
 
 declare module '@glint/environment-ember-loose/registry' {
-  export default interface Registry extends EmberBootstrapRegistry {}
+  export default interface Registry extends EmberBootstrapRegistry {
+    'bs-conditional-attribute': typeof BsConditionalAttribute;
+  }
 }


### PR DESCRIPTION
As part of the Typescript conversion of `bs-modal`, I noticed that the `@` on `@onClick` was missing for the submit button.

I have added tests for the submit and close button, and they seem to be fine with or without the `@`, but to keep in line with Ember's usual style, we should put the `@` in there anyway. 