### PR TITLE
Styling of toggle button yielded by BsDropdown via arguments is ignored 

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown/button.hbs
+++ b/ember-bootstrap/addon/components/bs-dropdown/button.hbs
@@ -4,6 +4,10 @@
   {{! template-lint-disable no-capital-arguments no-args-paths }}
   @block={{this.args.block}}
   @onClick={{@onClick}}
+  @active={{@active}}
+  @size={{@size}}
+  @type={{@type}}
+  @outline={{@outline}}
   aria-expanded={{if @isOpen "true" "false"}}
   class="dropdown-toggle"
   ...attributes

--- a/test-app/tests/integration/components/bs-dropdown/button-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/button-test.js
@@ -29,7 +29,7 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
 
   test('dropdown button has correct css outline class', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.button @outline="true">Test</dd.button></BsDropdown>`,
+      hbs`<BsDropdown as |dd|><dd.button @outline={{true}}>Test</dd.button></BsDropdown>`,
     );
 
     assert
@@ -46,5 +46,13 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
     );
 
     assert.dom('button').hasClass('btn-lg', 'dropdown button has large size');
+  });
+
+  test('dropdown button has correct css active class', async function (assert) {
+    await render(
+      hbs`<BsDropdown as |dd|><dd.button @active={{true}}>Test</dd.button></BsDropdown>`,
+    );
+
+    assert.dom('button').hasClass('active', 'dropdown button is active');
   });
 });

--- a/test-app/tests/integration/components/bs-dropdown/button-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/button-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
 
   test('dropdown button has coorect css type class', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.button @type="primary">Test</dd.button></BsDropdown>`,
+      hbs`<BsDropdown as |dd|><dd.button @type='primary'>Test</dd.button></BsDropdown>`,
     );
 
     assert
@@ -42,7 +42,7 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
 
   test('dropdown button has correct size', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.button @size="lg">Test</dd.button></BsDropdown>`,
+      hbs`<BsDropdown as |dd|><dd.button @size='lg'>Test</dd.button></BsDropdown>`,
     );
 
     assert.dom('button').hasClass('btn-lg', 'dropdown button has large size');

--- a/test-app/tests/integration/components/bs-dropdown/button-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/button-test.js
@@ -17,7 +17,7 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
     assert.dom('.dropdown-toggle').exists('has dropdown-toggle class');
   });
 
-  test('dropdown button has coorect css type class', async function (assert) {
+  test('dropdown button has correct css type class', async function (assert) {
     await render(
       hbs`<BsDropdown as |dd|><dd.button @type='primary'>Test</dd.button></BsDropdown>`,
     );

--- a/test-app/tests/integration/components/bs-dropdown/button-test.js
+++ b/test-app/tests/integration/components/bs-dropdown/button-test.js
@@ -16,4 +16,35 @@ module('Integration | Component | bs-dropdown/button', function (hooks) {
     assert.dom('button').exists('dropdown button is a button');
     assert.dom('.dropdown-toggle').exists('has dropdown-toggle class');
   });
+
+  test('dropdown button has coorect css type class', async function (assert) {
+    await render(
+      hbs`<BsDropdown as |dd|><dd.button @type="primary">Test</dd.button></BsDropdown>`,
+    );
+
+    assert
+      .dom('button')
+      .hasClass('btn-primary', 'dropdown button has primary type');
+  });
+
+  test('dropdown button has correct css outline class', async function (assert) {
+    await render(
+      hbs`<BsDropdown as |dd|><dd.button @outline="true">Test</dd.button></BsDropdown>`,
+    );
+
+    assert
+      .dom('button')
+      .hasClass(
+        'btn-outline-secondary',
+        'dropdown button has secondary outline type',
+      );
+  });
+
+  test('dropdown button has correct size', async function (assert) {
+    await render(
+      hbs`<BsDropdown as |dd|><dd.button @size="lg">Test</dd.button></BsDropdown>`,
+    );
+
+    assert.dom('button').hasClass('btn-lg', 'dropdown button has large size');
+  });
 });


### PR DESCRIPTION
CSS not applied when using `@type` parameter on `bs-dropdown-button`

- Modify api/parameters
- Add tests

This regression has been introduce by: https://github.com/ember-bootstrap/ember-bootstrap/pull/2111/files