### PR TITLE
allow action helper and modifier deprecation for now

### DIFF
--- a/test-app/tests/helpers/setup-no-deprecations.ts
+++ b/test-app/tests/helpers/setup-no-deprecations.ts
@@ -13,9 +13,8 @@ const ignoredDeprecations = [
   // @todo investigate what is still triggering the deprecation, might be some internals like
   // ember-cli-app-version or ember-export-application-global
   /@ember\/string/,
-  // @todo ADD LINK TO GITHUB ISSUE
+  // @todo https://github.com/ember-bootstrap/ember-bootstrap/issues/2131
   /Usage of the `\(action\)` helper is deprecated/,
-  // @todo ADD LINK TO GITHUB ISSUE
   /Usage of the `{{action}}` modifier is deprecated/,
 ];
 

--- a/test-app/tests/helpers/setup-no-deprecations.ts
+++ b/test-app/tests/helpers/setup-no-deprecations.ts
@@ -13,6 +13,10 @@ const ignoredDeprecations = [
   // @todo investigate what is still triggering the deprecation, might be some internals like
   // ember-cli-app-version or ember-export-application-global
   /@ember\/string/,
+  // @todo ADD LINK TO GITHUB ISSUE
+  /Usage of the `\(action\)` helper is deprecated/,
+  // @todo ADD LINK TO GITHUB ISSUE
+  /Usage of the `{{action}}` modifier is deprecated/,
 ];
 
 export default function setupNoDeprecations({


### PR DESCRIPTION
Deprecations for `(action)` template helper and `{{action}}` modifier landed in latest beta version of Ember. We are still relying a lot on both. We should fix that as soon as possible. But we should not fail CI due to it as that blocks other development.