### PR TITLE
Fix API page generation of TypeScript components

### DIFF
--- a/docs/yuidoc.json
+++ b/docs/yuidoc.json
@@ -3,6 +3,7 @@
   "description": "Twitter Bootstrap components for Ember.js",
   "version": "3.1.3",
   "options": {
+    "extension": ".js,.ts",
     "paths": [
       "../ember-bootstrap/addon/components",
       "../ember-bootstrap/addon/mixins"


### PR DESCRIPTION
Yuidoc only scans for .js files by default. This should add back the components that have been updated to Typescript.

Fixes: #2124