### PR TITLE
Run tests for fastboot with ember-canary and Embroider

### DIFF
--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -60,10 +60,6 @@ module.exports = async function () {
         },
         env: {
           // FAIL_ON_DEPRECATION: true,
-
-          // TODO: Enable again when FastBoot is ready for Ember 5
-          // https://github.com/ember-fastboot/ember-cli-fastboot/pull/905
-          FASTBOOT_DISABLED: true,
         },
       },
       {

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -72,9 +72,6 @@ module.exports = async function () {
         },
       },
       embroiderSafe({
-        env: {
-          FASTBOOT_DISABLED: true,
-        },
         npm: {
           devDependencies: {
             bootstrap: bootstrapVersion,
@@ -82,9 +79,6 @@ module.exports = async function () {
         },
       }),
       embroiderOptimized({
-        env: {
-          FASTBOOT_DISABLED: true,
-        },
         npm: {
           devDependencies: {
             bootstrap: bootstrapVersion,

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -6,15 +6,6 @@ const { maybeEmbroider } = require('@embroider/test-setup');
 module.exports = function (defaults) {
   const trees = {};
 
-  // Exclude FastBoot tests if FASTBOOT_DISABLED is set,
-  // to enable Embroider tests until https://github.com/embroider-build/embroider/issues/160 is resolved.
-  if (process.env.FASTBOOT_DISABLED) {
-    const Funnel = require('broccoli-funnel');
-    trees.tests = new Funnel('tests', {
-      exclude: ['fastboot/**'],
-    });
-  }
-
   const options = {
     'ember-bootstrap': {},
     'ember-cli-babel': {
@@ -26,11 +17,6 @@ module.exports = function (defaults) {
       watchDependencies: ['ember-bootstrap'],
     },
     trees,
-    addons: {
-      exclude: process.env.FASTBOOT_DISABLED
-        ? ['ember-cli-fastboot-testing']
-        : [],
-    },
   };
 
   const app = new EmberApp(defaults, options);


### PR DESCRIPTION
The mentioned issue has been resolved and the tests work after removing the option