### PR TITLE
Tests: Remove action helper from bs-dropdown tests and convert to gjs

### DIFF
--- a/test-app/tests/integration/components/bs-dropdown-test.gjs
+++ b/test-app/tests/integration/components/bs-dropdown-test.gjs
@@ -1,6 +1,12 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, focus, render, triggerKeyEvent } from '@ember/test-helpers';
+import {
+  click,
+  focus,
+  render,
+  settled,
+  triggerKeyEvent,
+} from '@ember/test-helpers';
 import {
   dropdownVisibilityElementSelector,
   isHidden,
@@ -9,42 +15,54 @@ import {
   test,
   versionDependent,
 } from '../../helpers/bootstrap';
-import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
+import { on } from '@ember/modifier';
+import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
+import { tracked } from '@glimmer/tracking';
 
 module('Integration | Component | bs-dropdown', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
   test('dropdown container has dropdown class', async function (assert) {
-    await render(hbs`<BsDropdown>Test</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown>Test</BsDropdown>
+      </template>,
+    );
 
     assert.dom('.dropdown').exists('has dropdown class');
   });
 
   test('dropdown container supports dropup style', async function (assert) {
-    await render(hbs`<BsDropdown @direction='up'>Test</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @direction='up'>Test</BsDropdown>
+      </template>,
+    );
 
     assert.dom('.dropup').exists('has dropup class');
   });
 
   test('dropdown container supports dropright style', async function (assert) {
-    await render(hbs`<BsDropdown @direction='right'>Test</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @direction='right'>Test</BsDropdown>
+      </template>,
+    );
 
     let droprightClass = versionDependent('.dropright', '.dropend');
     assert.dom(droprightClass).exists('has dropright class');
   });
 
   test('dropdown container supports dropleft style', async function (assert) {
-    await render(hbs`<BsDropdown @direction='left'>Test</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @direction='left'>Test</BsDropdown>
+      </template>,
+    );
 
     let dropleftClass = versionDependent('.dropleft', '.dropstart');
     assert.dom(dropleftClass).exists('has dropleft class');
@@ -52,20 +70,24 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('supports setting btn-group class', async function (assert) {
     await render(
-      hbs`<BsDropdown class='btn-group' as |dd|><dd.button>Dropdown
-    <span class='caret'></span></dd.button><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown class='btn-group' as |dd|><dd.button>Dropdown
+            <span class='caret'></span></dd.button><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
     assert.dom('.btn-group').exists('has btn-group class');
   });
 
   test('dropdown-toggle toggles dropdown visibility', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     assert.dom('.dropdown-menu').doesNotExist('Dropdown is closed');
@@ -80,10 +102,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('dropdown toggle has aria-expanded attribute', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     assert.dom('.dropdown-toggle').hasAttribute('aria-expanded', 'false');
@@ -95,10 +119,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('dropdown button has aria-expanded attribute', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.button>Dropdown
-    <span class='caret'></span></dd.button><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.button>Dropdown
+            <span class='caret'></span></dd.button><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     assert.dom('.dropdown-toggle').hasAttribute('aria-expanded', 'false');
@@ -110,10 +136,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('opened dropdown will close on outside click', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     await click('a.dropdown-toggle');
@@ -126,14 +154,15 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('opened dropdown will not close on outside click if onHide returns false', async function (assert) {
-    this.set('onHide', () => {
-      return false;
-    });
+    const onHide = () => false;
+
     await render(
-      hbs`<BsDropdown @onHide={{this.onHide}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown @onHide={{onHide}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     await click('a.dropdown-toggle');
@@ -147,10 +176,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('clicking dropdown menu will close it', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
@@ -163,14 +194,15 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('clicking dropdown menu will not close it if onHide returns false', async function (assert) {
-    this.set('onHide', () => {
-      return false;
-    });
+    const onHide = () => false;
+
     await render(
-      hbs`<BsDropdown @onHide={{this.onHide}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown @onHide={{onHide}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
@@ -185,17 +217,21 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   test('dropdown will close on click, when default is prevented, propagation is stopped', async function (assert) {
     assert.expect(3);
 
-    this.set('stopEvent', (event) => {
+    const stopEvent = (event) => {
       event.stopPropagation();
       event.preventDefault();
       assert.ok('stopped event');
-    });
+    };
 
-    await render(hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu><li><a href='#'>Something</a></li></dd.menu>
-</BsDropdown>
-<div id='target' role='button' onclick={{action this.stopEvent}} />`);
+    await render(
+      <template>
+        <BsDropdown as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu><li><a href='#'>Something</a></li></dd.menu>
+        </BsDropdown>
+        <div id='target' role='button' onclick={{stopEvent}} />
+      </template>,
+    );
 
     await click('a.dropdown-toggle');
     assert.dom(`.${openClass()}`).exists('Dropdown is open');
@@ -205,10 +241,14 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('clicking dropdown menu when closeOnMenuClick is false will not close it', async function (assert) {
-    await render(hbs`<BsDropdown @closeOnMenuClick={{false}} as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu><li><a href='#'>Something</a></li></dd.menu>
-</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @closeOnMenuClick={{false}} as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu><li><a href='#'>Something</a></li></dd.menu>
+        </BsDropdown>
+      </template>,
+    );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
     assert
@@ -223,10 +263,14 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('clicking dropdown menu when closeOnMenuClick is false will not close it, even after opening the menu again', async function (assert) {
-    await render(hbs`<BsDropdown @closeOnMenuClick={{false}} as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu><li><a href='#'>Something</a></li></dd.menu>
-</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @closeOnMenuClick={{false}} as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu><li><a href='#'>Something</a></li></dd.menu>
+        </BsDropdown>
+      </template>,
+    );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
     assert
@@ -259,10 +303,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('clicking outside dropdown menu when closeOnMenuClick is false will close it', async function (assert) {
     await render(
-      hbs`<BsDropdown @closeOnMenuClick={{false}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown @closeOnMenuClick={{false}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
@@ -276,10 +322,13 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('clicking outside dropdown menu when closeOnMenuClick is false and renderInPlace is false will close it', async function (assert) {
     await render(
-      hbs`<div id='ember-bootstrap-wormhole'></div>
-<BsDropdown @closeOnMenuClick={{false}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu @renderInPlace={{false}}><li
-    ><a href='#'>Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>
+        <BsDropdown @closeOnMenuClick={{false}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu
+            @renderInPlace={{false}}
+          ><li><a href='#'>Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
     await click('a.dropdown-toggle');
     assert.dom('.dropdown-menu').exists();
@@ -293,11 +342,13 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('child components can access isOpen property', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle><span id='toggleText'>{{if
-        dd.isOpen
-        'open'
-        'closed'
-      }}</span></dd.toggle></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle><span id='toggleText'>{{if
+                dd.isOpen
+                'open'
+                'closed'
+              }}</span></dd.toggle></BsDropdown>
+      </template>,
     );
 
     assert.dom('#toggleText').hasText('closed', 'Dropdown is closed');
@@ -308,22 +359,26 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('clicking on a menu item with an action will perform that action before closing the dropdown', async function (assert) {
-    const actionStub = this.set('action', sinon.stub());
+    const actionStub = sinon.stub();
 
-    await render(hbs`<BsDropdown as |dd|>
-  <dd.toggle data-test-dropdown-toggle>
-    Dropdown
-    <span class='caret'></span>
-  </dd.toggle>
-  <dd.menu>
-    <li><a
-        href='#'
-        role='button'
-        data-test-dropdown-item
-        {{on 'click' this.action}}
-      >Something</a></li>
-  </dd.menu>
-</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown as |dd|>
+          <dd.toggle data-test-dropdown-toggle>
+            Dropdown
+            <span class='caret'></span>
+          </dd.toggle>
+          <dd.menu>
+            <li><a
+                href='#'
+                role='button'
+                data-test-dropdown-item
+                {{on 'click' actionStub}}
+              >Something</a></li>
+          </dd.menu>
+        </BsDropdown>
+      </template>,
+    );
     await click('[data-test-dropdown-toggle]');
     await click('[data-test-dropdown-item]');
 
@@ -331,117 +386,138 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('opening dropdown calls onShow action', async function (assert) {
-    let action = sinon.spy();
-    this.actions.show = action;
+    const showAction = sinon.spy();
+
     await render(
-      hbs`<BsDropdown @onShow={{action 'show'}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown @onShow={{showAction}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     await click('a.dropdown-toggle');
-    assert.ok(action.calledOnce);
+    assert.ok(showAction.calledOnce);
   });
 
   test('closing dropdown calls onHide action', async function (assert) {
-    let action = sinon.spy();
-    this.actions.hide = action;
+    const hideAction = sinon.spy();
+
     await render(
-      hbs`<BsDropdown @onHide={{action 'hide'}} as |dd|><dd.toggle>Dropdown
-    <span class='caret'></span></dd.toggle><dd.menu><li><a
-        href='#'
-      >Something</a></li></dd.menu></BsDropdown>`,
+      <template>
+        <BsDropdown @onHide={{hideAction}} as |dd|><dd.toggle>Dropdown
+            <span class='caret'></span></dd.toggle><dd.menu><li><a
+                href='#'
+              >Something</a></li></dd.menu></BsDropdown>
+      </template>,
     );
 
     await click('a.dropdown-toggle');
     await click('.dropdown-menu a');
-    assert.ok(action.calledOnce);
+    assert.ok(hideAction.calledOnce);
   });
 
   test('dropdown yields the openDropdown action', async function (assert) {
-    let action = sinon.spy();
-    this.actions.show = action;
-    await render(hbs`<BsDropdown @onShow={{action 'show'}} as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu><li><a href='#'>Something</a></li></dd.menu>
-  <a
-    href='#'
-    role='button'
-    {{action dd.openDropdown}}
-    class='custom-open'
-  >Custom open link</a>
-</BsDropdown>`);
+    const showAction = sinon.spy();
+
+    await render(
+      <template>
+        <BsDropdown @onShow={{showAction}} as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu><li><a href='#'>Something</a></li></dd.menu>
+          <a
+            href='#'
+            role='button'
+            {{on 'click' dd.openDropdown}}
+            class='custom-open'
+          >Custom open link</a>
+        </BsDropdown>
+      </template>,
+    );
 
     await click('a.custom-open');
-    assert.ok(action.calledOnce);
+    assert.ok(showAction.calledOnce);
   });
 
   test('dropdown yields the closeDropdown action', async function (assert) {
-    let hide = sinon.spy();
-    this.actions.hide = hide;
-    await render(hbs`<BsDropdown @closeOnMenuClick={{false}} @onHide={{action 'hide'}} as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu>
-    <li>
-      <a href='#'>Something</a>
-      <a
-        href='#'
-        role='button'
-        {{action dd.closeDropdown}}
-        class='custom-close'
-      >Custom close link</a>
-    </li>
-  </dd.menu>
-</BsDropdown>`);
+    const hideAction = sinon.spy();
+
+    await render(
+      <template>
+        <BsDropdown @closeOnMenuClick={{false}} @onHide={{hideAction}} as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu>
+            <li>
+              <a href='#'>Something</a>
+              <a
+                href='#'
+                role='button'
+                {{on 'click' dd.closeDropdown}}
+                class='custom-close'
+              >Custom close link</a>
+            </li>
+          </dd.menu>
+        </BsDropdown>
+      </template>,
+    );
 
     await click('a.dropdown-toggle');
     await click('.custom-close');
-    assert.ok(hide.calledOnce);
+    assert.ok(hideAction.calledOnce);
   });
 
   test('dropdown yields the toggleDropdown action', async function (assert) {
-    const show = this.set('show', sinon.stub());
-    const hide = this.set('hide', sinon.stub());
-    await render(hbs`<BsDropdown
-  @closeOnMenuClick={{false}}
-  @onShow={{this.show}}
-  @onHide={{this.hide}}
-  as |dd|
->
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu><li><a
-        href='#'
-        data-test-dropdown-menu-toggle
-        {{on 'click' dd.toggleDropdown}}
-      >Something</a></li></dd.menu>
-  <a
-    href='#'
-    data-test-dropdown-outside-toggle
-    {{on 'click' dd.toggleDropdown}}
-    role='button'
-  >Custom toggle link</a>
-</BsDropdown>`);
+    const showAction = sinon.stub();
+    const hideAction = sinon.stub();
+
+    await render(
+      <template>
+        <BsDropdown
+          @closeOnMenuClick={{false}}
+          @onShow={{showAction}}
+          @onHide={{hideAction}}
+          as |dd|
+        >
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu><li><a
+                href='#'
+                data-test-dropdown-menu-toggle
+                {{on 'click' dd.toggleDropdown}}
+              >Something</a></li></dd.menu>
+          <a
+            href='#'
+            data-test-dropdown-outside-toggle
+            {{on 'click' dd.toggleDropdown}}
+            role='button'
+          >Custom toggle link</a>
+        </BsDropdown>
+      </template>,
+    );
 
     await click('[data-test-dropdown-outside-toggle]');
-    assert.ok(show.calledOnce, 'Show callback was called');
+    assert.ok(showAction.calledOnce, 'Show callback was called');
 
     // Test the toggle yield by clicking a button in the menu.
     // If we don't, the event that closes the dropdown will be the 'outside click', which is not tested here.
     // For this reason, if [data-test-dropdown-outside-toggle] is clicked, hide will get called twice.
     await click('[data-test-dropdown-menu-toggle]');
-    assert.ok(hide.calledOnce, 'Hide callback was called');
+    assert.ok(hideAction.calledOnce, 'Hide callback was called');
   });
 
   test('opening dropdown makes the menu visible', async function (assert) {
-    await render(hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu as |menu|>
-    <menu.item>
-      <menu.link-to @route='index'>Home</menu.link-to>
-    </menu.item>
-  </dd.menu>
-</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown as |dd|>
+          <dd.toggle>Dropdown</dd.toggle>
+          <dd.menu as |menu|>
+            <menu.item>
+              <menu.link-to @route='index'>Home</menu.link-to>
+            </menu.item>
+          </dd.menu>
+        </BsDropdown>
+      </template>,
+    );
 
     assert.ok(isHidden(this.element.querySelector('.dropdown-menu')));
 
@@ -454,16 +530,23 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   test('dropdown in nav disables dynamic positioning', async function (assert) {
-    this.set('inNav', false);
+    class State {
+      @tracked inNav = false;
+    }
+    const state = new State();
 
-    await render(hbs`<BsDropdown @inNav={{this.inNav}} as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu as |menu|>
-    <menu.item>
-      <menu.link-to @route='index'>Home</menu.link-to>
-    </menu.item>
-  </dd.menu>
-</BsDropdown>`);
+    await render(
+      <template>
+        <BsDropdown @inNav={{state.inNav}} as |dd|>
+          <dd.toggle>Dropdown</dd.toggle>
+          <dd.menu as |menu|>
+            <menu.item>
+              <menu.link-to @route='index'>Home</menu.link-to>
+            </menu.item>
+          </dd.menu>
+        </BsDropdown>
+      </template>,
+    );
 
     await click('a.dropdown-toggle');
 
@@ -472,7 +555,8 @@ module('Integration | Component | bs-dropdown', function (hooks) {
       'Dynamic positioning applied when inNav is set to false',
     );
 
-    this.set('inNav', true);
+    state.inNav = true;
+    await settled();
 
     assert.strictEqual(
       this.element.querySelector('.dropdown-menu').style.length,
@@ -483,11 +567,15 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('dropdown menu can be rendered in a wormhole', async function (assert) {
     await render(
-      hbs`<div id='ember-bootstrap-wormhole'></div>
-<BsDropdown as |dd|>
-  <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
-  <dd.menu @renderInPlace={{false}}><li><a href='#'>Something</a></li></dd.menu>
-</BsDropdown>`,
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>
+        <BsDropdown as |dd|>
+          <dd.toggle>Dropdown <span class='caret'></span></dd.toggle>
+          <dd.menu @renderInPlace={{false}}><li><a
+                href='#'
+              >Something</a></li></dd.menu>
+        </BsDropdown>
+      </template>,
     );
 
     await click('a.dropdown-toggle');
@@ -497,19 +585,29 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   module('keyboard control', function () {
+    class State {
+      @tracked renderInPlace = false;
+    }
+    const state = new State();
+
     function keyboardTest() {
       test(`should have correct default element focused`, async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
-        let expectedFocusElement = this.renderInPlace
+        let expectedFocusElement = state.renderInPlace
           ? 'a.dropdown-toggle'
           : '.dropdown-menu';
 
@@ -518,12 +616,17 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should show if down key is pressed on toggle', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await focus('a.dropdown-toggle');
@@ -534,12 +637,17 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should show if down key is pressed on button', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.button>Dropdown</dd.button>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.button>Dropdown</dd.button>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await focus('button.dropdown-toggle');
@@ -550,12 +658,17 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should hide if pressing escape', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
@@ -572,12 +685,17 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should hide if tabbing outside of menu', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
@@ -591,12 +709,17 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should not hide if tabbing inside of menu', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
@@ -610,21 +733,23 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should focus next/previous element when using keyboard navigation', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a
-        class='dropdown-item'
-        href='#'
-        id='item1'
-      >Something</a></menu.item>
-    <menu.item><a
-        class='dropdown-item'
-        href='#'
-        id='item2'
-      >Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                    id='item1'
+                  >Something</a></menu.item>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                    id='item2'
+                  >Something</a></menu.item>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
@@ -641,22 +766,24 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
       test('should hide and focus next element when tabbing outside of menu ', async function (assert) {
         await render(
-          hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}} as |menu|>
-    <menu.item><a
-        class='dropdown-item'
-        href='#'
-        id='item1'
-      >Something</a></menu.item>
-    <menu.item><a
-        class='dropdown-item'
-        href='#'
-        id='item2'
-      >Something</a></menu.item>
-  </dd.menu>
-  <button type='button' id='next'>Next</button>
-</BsDropdown>`,
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                    id='item1'
+                  >Something</a></menu.item>
+                <menu.item><a
+                    class='dropdown-item'
+                    href='#'
+                    id='item2'
+                  >Something</a></menu.item>
+              </dd.menu>
+              <button type='button' id='next'>Next</button>
+            </BsDropdown>
+          </template>,
         );
 
         await click('a.dropdown-toggle');
@@ -674,14 +801,18 @@ module('Integration | Component | bs-dropdown', function (hooks) {
       });
 
       test('should ignore keyboard events within <input>s and <textarea>s, except for escape key', async function (assert) {
-        await render(hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}}>
-    <a class='dropdown-item' href='#' id='item1'>Something</a>
-    <input type='text' />
-    <textarea></textarea>
-  </dd.menu>
-</BsDropdown>`);
+        await render(
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}}>
+                <a class='dropdown-item' href='#' id='item1'>Something</a>
+                <input type='text' />
+                <textarea></textarea>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
+        );
 
         await click('a.dropdown-toggle');
         await focus('input');
@@ -699,14 +830,19 @@ module('Integration | Component | bs-dropdown', function (hooks) {
       });
 
       test('should skip disabled element when using keyboard navigation', async function (assert) {
-        await render(hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu @renderInPlace={{this.renderInPlace}}>
-    <a class='dropdown-item disabled' href='#sub1'>Submenu 1</a>
-    <button class='dropdown-item' type='button' disabled>Disabled button</button>
-    <a class='dropdown-item' href='#' id='item1'>Something</a>
-  </dd.menu>
-</BsDropdown>`);
+        await render(
+          <template>
+            <BsDropdown as |dd|>
+              <dd.toggle>Dropdown</dd.toggle>
+              <dd.menu @renderInPlace={{state.renderInPlace}}>
+                <a class='dropdown-item disabled' href='#sub1'>Submenu 1</a>
+                <button class='dropdown-item' type='button' disabled>Disabled
+                  button</button>
+                <a class='dropdown-item' href='#' id='item1'>Something</a>
+              </dd.menu>
+            </BsDropdown>
+          </template>,
+        );
 
         await click('a.dropdown-toggle');
 
@@ -717,14 +853,14 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
     module('in place', function (hooks) {
       hooks.beforeEach(function () {
-        this.renderInPlace = true;
+        state.renderInPlace = true;
       });
       keyboardTest();
     });
 
     module('in wormhole', function () {
       hooks.beforeEach(function () {
-        this.renderInPlace = false;
+        state.renderInPlace = false;
       });
       keyboardTest();
     });
@@ -732,12 +868,18 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
   test('it passes accessibility checks', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|>
-  <dd.toggle>Dropdown</dd.toggle>
-  <dd.menu as |menu|>
-    <menu.item><a class='dropdown-item' href='#'>Something</a></menu.item>
-  </dd.menu>
-</BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|>
+          <dd.toggle>Dropdown</dd.toggle>
+          <dd.menu as |menu|>
+            <menu.item>
+              <a class='dropdown-item' href='#'>
+                Something
+              </a>
+            </menu.item>
+          </dd.menu>
+        </BsDropdown>
+      </template>,
     );
 
     await a11yAudit();

--- a/test-app/tests/integration/components/bs-dropdown-test.gjs
+++ b/test-app/tests/integration/components/bs-dropdown-test.gjs
@@ -585,7 +585,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   module('keyboard control', function () {
-    let renderInPlace = undefined;
+    let renderInPlace;
 
     function keyboardTest() {
       test(`should have correct default element focused`, async function (assert) {

--- a/test-app/tests/integration/components/bs-dropdown-test.gjs
+++ b/test-app/tests/integration/components/bs-dropdown-test.gjs
@@ -585,10 +585,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   module('keyboard control', function () {
-    class State {
-      @tracked renderInPlace = false;
-    }
-    const state = new State();
+    let renderInPlace = undefined;
 
     function keyboardTest() {
       test(`should have correct default element focused`, async function (assert) {
@@ -596,7 +593,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -607,7 +604,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
         );
 
         await click('a.dropdown-toggle');
-        let expectedFocusElement = state.renderInPlace
+        let expectedFocusElement = renderInPlace
           ? 'a.dropdown-toggle'
           : '.dropdown-menu';
 
@@ -619,7 +616,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -640,7 +637,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.button>Dropdown</dd.button>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -661,7 +658,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -688,7 +685,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -712,7 +709,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -736,7 +733,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -769,7 +766,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}} as |menu|>
+              <dd.menu @renderInPlace={{renderInPlace}} as |menu|>
                 <menu.item><a
                     class='dropdown-item'
                     href='#'
@@ -805,7 +802,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}}>
+              <dd.menu @renderInPlace={{renderInPlace}}>
                 <a class='dropdown-item' href='#' id='item1'>Something</a>
                 <input type='text' />
                 <textarea></textarea>
@@ -834,7 +831,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
           <template>
             <BsDropdown as |dd|>
               <dd.toggle>Dropdown</dd.toggle>
-              <dd.menu @renderInPlace={{state.renderInPlace}}>
+              <dd.menu @renderInPlace={{renderInPlace}}>
                 <a class='dropdown-item disabled' href='#sub1'>Submenu 1</a>
                 <button class='dropdown-item' type='button' disabled>Disabled
                   button</button>
@@ -853,14 +850,14 @@ module('Integration | Component | bs-dropdown', function (hooks) {
 
     module('in place', function (hooks) {
       hooks.beforeEach(function () {
-        state.renderInPlace = true;
+        renderInPlace = true;
       });
       keyboardTest();
     });
 
     module('in wormhole', function () {
       hooks.beforeEach(function () {
-        state.renderInPlace = false;
+        renderInPlace = false;
       });
       keyboardTest();
     });

--- a/test-app/tests/integration/components/bs-dropdown-test.gjs
+++ b/test-app/tests/integration/components/bs-dropdown-test.gjs
@@ -585,9 +585,7 @@ module('Integration | Component | bs-dropdown', function (hooks) {
   });
 
   module('keyboard control', function () {
-    let renderInPlace;
-
-    function keyboardTest() {
+    function keyboardTest(renderInPlace) {
       test(`should have correct default element focused`, async function (assert) {
         await render(
           <template>
@@ -848,18 +846,12 @@ module('Integration | Component | bs-dropdown', function (hooks) {
       });
     }
 
-    module('in place', function (hooks) {
-      hooks.beforeEach(function () {
-        renderInPlace = true;
-      });
-      keyboardTest();
+    module('in place', function () {
+      keyboardTest(true);
     });
 
     module('in wormhole', function () {
-      hooks.beforeEach(function () {
-        renderInPlace = false;
-      });
-      keyboardTest();
+      keyboardTest(false);
     });
   });
 

--- a/test-app/tests/integration/components/bs-dropdown/toggle-test.gjs
+++ b/test-app/tests/integration/components/bs-dropdown/toggle-test.gjs
@@ -1,23 +1,19 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
+import BsDropdown from 'ember-bootstrap/components/bs-dropdown';
 
 module('Integration | Component | bs-dropdown/toggle', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
   test('toggle has correct default markup', async function (assert) {
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle>Test</dd.toggle></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|><dd.toggle>Test</dd.toggle></BsDropdown>
+      </template>,
     );
 
     assert.dom('a').exists('toggle is an anchor tag by default');
@@ -27,14 +23,15 @@ module('Integration | Component | bs-dropdown/toggle', function (hooks) {
   });
 
   test('clicking toggle sends onClick action', async function (assert) {
-    let action = sinon.spy();
-    this.actions.click = action;
+    const onClick = sinon.stub();
     await render(
-      hbs`<BsDropdown as |dd|><dd.toggle
-    @onClick={{action 'click'}}
-  >Test</dd.toggle></BsDropdown>`,
+      <template>
+        <BsDropdown as |dd|>
+          <dd.toggle @onClick={{onClick}}>Test</dd.toggle>
+        </BsDropdown>
+      </template>,
     );
     await click('a');
-    assert.ok(action.calledOnce, 'onClick action has been called.');
+    assert.ok(onClick.calledOnce, 'onClick action has been called.');
   });
 });


### PR DESCRIPTION
I have a branch on my own repo that removes all of the action helpers, but the changeset for some of them is quite large, so I'm splitting them up in a few separate PRs.