### PR TITLE
Tests: Remove remaining action helpers from tests and convert to gjs

### DIFF
--- a/test-app/tests/integration/components/bs-accordion/item-test.gjs
+++ b/test-app/tests/integration/components/bs-accordion/item-test.gjs
@@ -1,7 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import {
   accordionClassFor,
   accordionItemBodyClass,
@@ -14,20 +13,17 @@ import {
 } from '../../../helpers/bootstrap';
 import setupNoDeprecations from '../../../helpers/setup-no-deprecations';
 import sinon from 'sinon';
+import BsAccordionItem from 'ember-bootstrap/components/bs-accordion/item';
 
 module('Integration | Component | bs-accordion-item', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
 
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
-
   test('accordion item has correct default markup', async function (assert) {
     await render(
-      hbs`<BsAccordion::Item @title='TITLE'>CONTENT</BsAccordion::Item>`,
+      <template>
+        <BsAccordionItem @title='TITLE'>CONTENT</BsAccordionItem>
+      </template>,
     );
     assert
       .dom(`.${accordionItemClass()}`)
@@ -57,25 +53,30 @@ module('Integration | Component | bs-accordion-item', function (hooks) {
   });
 
   test('calls onClick action when clicking heading', async function (assert) {
-    let action = sinon.spy();
-    this.actions.click = action;
+    const clickAction = sinon.spy();
     await render(
-      hbs`<BsAccordion::Item
-  @value={{1}}
-  @onClick={{action 'click'}}
-  @title='TITLE'
->CONTENT</BsAccordion::Item>`,
+      <template>
+        <BsAccordionItem
+          @value={{1}}
+          @onClick={{clickAction}}
+          @title='TITLE'
+        >CONTENT</BsAccordionItem>
+      </template>,
     );
 
     await click(accordionItemClickableSelector());
-    assert.ok(action.calledWith(1), 'onClick action has been called.');
+    assert.ok(clickAction.calledWith(1), 'onClick action has been called.');
   });
 
   test('renders a contextual title block', async function (assert) {
-    await render(hbs`<BsAccordion::Item as |aitem|>
-  <aitem.title>TITLE</aitem.title>
-  <aitem.body>CONTENT</aitem.body>
-</BsAccordion::Item>`);
+    await render(
+      <template>
+        <BsAccordionItem as |aitem|>
+          <aitem.title>TITLE</aitem.title>
+          <aitem.body>CONTENT</aitem.body>
+        </BsAccordionItem>
+      </template>,
+    );
 
     assert
       .dom(accordionTitleSelector())
@@ -86,15 +87,16 @@ module('Integration | Component | bs-accordion-item', function (hooks) {
   });
 
   test('accordion items can be disabled', async function (assert) {
-    let action = sinon.spy();
-    this.actions.click = action;
+    const clickAction = sinon.spy();
     await render(
-      hbs`<BsAccordion::Item
-  @value={{1}}
-  @disabled={{true}}
-  @onClick={{action 'click'}}
-  @title='TITLE'
->CONTENT</BsAccordion::Item>`,
+      <template>
+        <BsAccordionItem
+          @value={{1}}
+          @disabled={{true}}
+          @onClick={{clickAction}}
+          @title='TITLE'
+        >CONTENT</BsAccordionItem>
+      </template>,
     );
     assert
       .dom(accordionItemClickableSelector())
@@ -111,6 +113,9 @@ module('Integration | Component | bs-accordion-item', function (hooks) {
     } catch (e) {
       // click helper will throw on a disabled button
     }
-    assert.notOk(action.calledWith(1), 'onClick action should not be called');
+    assert.notOk(
+      clickAction.calledWith(1),
+      'onClick action should not be called',
+    );
   });
 });

--- a/test-app/tests/integration/components/bs-tab-test.gjs
+++ b/test-app/tests/integration/components/bs-tab-test.gjs
@@ -1,20 +1,17 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render, settled } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
+import BsTab from 'ember-bootstrap/components/bs-tab';
+import { tracked } from '@glimmer/tracking';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
 
 module('Integration | Component | bs-tab', function (hooks) {
   setupRenderingTest(hooks);
   setupNoDeprecations(hooks);
-
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
 
   function assertActiveTab(assert, tabIndex, active = true) {
     if (this.element.querySelectorAll('ul.nav.nav-tabs li a').length > 0) {
@@ -36,16 +33,24 @@ module('Integration | Component | bs-tab', function (hooks) {
   }
 
   test('it yields expected values', async function (assert) {
-    await render(hbs`<BsTab @fade={{false}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-  <div id='activeId'>{{tab.activeId}}</div>
-  <div id='switch' {{action tab.select 'pane2'}} role='button'></div>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{false}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+          <div id='activeId'>{{tab.activeId}}</div>
+          <div
+            id='switch'
+            {{on 'click' (fn tab.select 'pane2')}}
+            role='button'
+          ></div>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('.tab-pane').exists({ count: 2 }, 'yields tab pane component');
 
@@ -57,18 +62,26 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('it yields expected values [customTabs=true]', async function (assert) {
-    await render(hbs`<BsTab @fade={{false}} @customTabs={{true}} as |tab|>
-  <div class='tab-content'>
-    <tab.pane @id='pane1' @title='Tab 1'>
-      tabcontent 1
-    </tab.pane>
-    <tab.pane @id='pane2' @title='Tab 2'>
-      tabcontent 2
-    </tab.pane>
-    <div id='activeId'>{{tab.activeId}}</div>
-    <div id='switch' {{action tab.select 'pane2'}} role='button'></div>
-  </div>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{false}} @customTabs={{true}} as |tab|>
+          <div class='tab-content'>
+            <tab.pane @id='pane1' @title='Tab 1'>
+              tabcontent 1
+            </tab.pane>
+            <tab.pane @id='pane2' @title='Tab 2'>
+              tabcontent 2
+            </tab.pane>
+            <div id='activeId'>{{tab.activeId}}</div>
+            <div
+              id='switch'
+              {{on 'click' (fn tab.select 'pane2')}}
+              role='button'
+            ></div>
+          </div>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('.tab-pane').exists({ count: 2 }, 'yields tab pane component');
 
@@ -80,14 +93,18 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('it generates tab navigation', async function (assert) {
-    await render(hbs`<BsTab as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('ul.nav.nav-tabs').exists({ count: 1 }, 'has tabs navigation');
     assert
@@ -102,14 +119,18 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('tabs have proper aria roles', async function (assert) {
-    await render(hbs`<BsTab as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('ul.nav.nav-tabs').hasAttribute('role', 'tablist');
     assert.dom('ul.nav.nav-tabs > li > a').hasAttribute('role', 'tab');
@@ -123,34 +144,45 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('first tab is active by default', async function (assert) {
-    await render(hbs`<BsTab @fade={{false}} as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{false}} as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assertActiveTab.call(this, assert, 0, true);
     assertActiveTab.call(this, assert, 1, false);
   });
 
   test('activeId activates tabs', async function (assert) {
-    this.set('paneId', 'pane1');
-    await render(hbs`<BsTab @fade={{false}} @activeId={{this.paneId}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    class State {
+      @tracked paneId = 'pane1';
+    }
+    const state = new State();
+    await render(
+      <template>
+        <BsTab @fade={{false}} @activeId={{state.paneId}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assertActiveTab.call(this, assert, 0, true);
     assertActiveTab.call(this, assert, 1, false);
 
-    this.set('paneId', 'pane2');
+    state.paneId = 'pane2';
     await settled();
 
     assertActiveTab.call(this, assert, 0, false);
@@ -158,34 +190,45 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('first tab is active by default [fade]', async function (assert) {
-    await render(hbs`<BsTab @fade={{true}} as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{true}} as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assertActiveTab.call(this, assert, 0, true);
     assertActiveTab.call(this, assert, 1, false);
   });
 
   test('activeId activates tabs [fade]', async function (assert) {
-    this.set('paneId', 'pane1');
-    await render(hbs`<BsTab @fade={{true}} @activeId={{this.paneId}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    class State {
+      @tracked paneId = 'pane1';
+    }
+    const state = new State();
+    await render(
+      <template>
+        <BsTab @fade={{true}} @activeId={{state.paneId}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assertActiveTab.call(this, assert, 0, true);
     assertActiveTab.call(this, assert, 1, false);
 
-    this.set('paneId', 'pane2');
+    state.paneId = 'pane2';
     await settled();
 
     assertActiveTab.call(this, assert, 0, false);
@@ -193,20 +236,24 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('tab navigation is groupable', async function (assert) {
-    await render(hbs`<BsTab as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-  <tab.pane @title='Tab 3' @groupTitle='Dropdown'>
-    tabcontent 3
-  </tab.pane>
-  <tab.pane @title='Tab 4' @groupTitle='Dropdown'>
-    tabcontent 4
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+          <tab.pane @title='Tab 3' @groupTitle='Dropdown'>
+            tabcontent 3
+          </tab.pane>
+          <tab.pane @title='Tab 4' @groupTitle='Dropdown'>
+            tabcontent 4
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('ul.nav.nav-tabs').exists({ count: 1 }, 'has tabs navigation');
     assert
@@ -245,27 +292,35 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('customTabs disables tab navigation generation', async function (assert) {
-    await render(hbs`<BsTab @customTabs={{true}} as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @customTabs={{true}} as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('ul.nav.nav-tabs').doesNotExist('has no tabs navigation');
   });
 
   test('type sets tab navigation type', async function (assert) {
-    await render(hbs`<BsTab @type='pills' as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @type='pills' as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     assert.dom('ul.nav.nav-pills').exists({ count: 1 }, 'has pills navigation');
     assert
@@ -274,73 +329,89 @@ module('Integration | Component | bs-tab', function (hooks) {
   });
 
   test('calls onChange when changing active tab', async function (assert) {
-    let action = sinon.spy();
-    this.actions.change = action;
+    const onChange = sinon.spy();
 
-    await render(hbs`<BsTab @fade={{false}} @onChange={{action 'change'}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{false}} @onChange={{onChange}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     await click('ul.nav.nav-tabs li:nth-child(2) a');
-    assert.ok(action.calledWith('pane2', 'pane1'));
+    assert.ok(onChange.calledWith('pane2', 'pane1'));
 
     assertActiveTab.call(this, assert, 0, false);
     assertActiveTab.call(this, assert, 1, true);
   });
 
   test('when onChange returns false active tab is not changed', async function (assert) {
-    let action = sinon.stub();
-    action.returns(false);
-    this.actions.change = action;
+    const onChange = sinon.stub().returns(false);
 
-    await render(hbs`<BsTab @fade={{false}} @onChange={{action 'change'}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab @fade={{false}} @onChange={{onChange}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     await click('ul.nav.nav-tabs li:nth-child(2) a');
-    assert.ok(action.calledWith('pane2', 'pane1'));
+    assert.ok(onChange.calledWith('pane2', 'pane1'));
 
     assertActiveTab.call(this, assert, 0, true);
     assertActiveTab.call(this, assert, 1, false);
   });
 
   test('changing active tab does not change public activeId property (DDAU)', async function (assert) {
-    this.set('paneId', 'pane1');
-    await render(hbs`<BsTab @fade={{false}} @activeId={{this.paneId}} as |tab|>
-  <tab.pane @id='pane1' @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @id='pane2' @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    class State {
+      @tracked paneId = 'pane1';
+    }
+    const state = new State();
+    await render(
+      <template>
+        <BsTab @fade={{false}} @activeId={{state.paneId}} as |tab|>
+          <tab.pane @id='pane1' @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @id='pane2' @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
     await click('ul.nav.nav-tabs li:nth-child(2) a');
     assert.equal(
-      this.paneId,
+      state.paneId,
       'pane1',
       'Does not modify public activeId property',
     );
   });
 
   test('it passes accessibility checks', async function (assert) {
-    await render(hbs`<BsTab as |tab|>
-  <tab.pane @title='Tab 1'>
-    tabcontent 1
-  </tab.pane>
-  <tab.pane @title='Tab 2'>
-    tabcontent 2
-  </tab.pane>
-</BsTab>`);
+    await render(
+      <template>
+        <BsTab as |tab|>
+          <tab.pane @title='Tab 1'>
+            tabcontent 1
+          </tab.pane>
+          <tab.pane @title='Tab 2'>
+            tabcontent 2
+          </tab.pane>
+        </BsTab>
+      </template>,
+    );
 
     await a11yAudit({
       rules: {

--- a/test-app/tests/integration/components/bs-tab-test.gjs
+++ b/test-app/tests/integration/components/bs-tab-test.gjs
@@ -376,7 +376,7 @@ module('Integration | Component | bs-tab', function (hooks) {
 
   test('changing active tab does not change public activeId property (DDAU)', async function (assert) {
     class State {
-      @tracked paneId = 'pane1';
+      paneId = 'pane1';
     }
     const state = new State();
     await render(

--- a/test-app/tests/integration/components/bs-tooltip-test.gjs
+++ b/test-app/tests/integration/components/bs-tooltip-test.gjs
@@ -9,7 +9,6 @@ import {
   triggerEvent,
   waitUntil,
 } from '@ember/test-helpers';
-import { hbs } from 'ember-cli-htmlbars';
 import {
   delay,
   test,
@@ -26,17 +25,15 @@ import setupStylesheetSupport from '../../helpers/setup-stylesheet-support';
 import setupNoDeprecations from '../../helpers/setup-no-deprecations';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import sinon from 'sinon';
+import BsTooltip from 'ember-bootstrap/components/bs-tooltip';
+import BsTooltipElement from 'ember-bootstrap/components/bs-tooltip/element';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
 
 module('Integration | Component | bs-tooltip', function (hooks) {
   setupRenderingTest(hooks);
   setupStylesheetSupport(hooks);
   setupNoDeprecations(hooks);
-
-  hooks.beforeEach(function () {
-    this.actions = {};
-    this.send = (actionName, ...args) =>
-      this.actions[actionName].apply(this, args);
-  });
 
   function isVisible(tt) {
     return (
@@ -48,9 +45,13 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it has correct markup', async function (assert) {
     // Template block usage:
-    await render(hbs`<BsTooltip @id='tooltip-element' @fade={{true}} @visible={{true}}>
-  template block text
-</BsTooltip>`);
+    await render(
+      <template>
+        <BsTooltip @id='tooltip-element' @fade={{true}} @visible={{true}}>
+          template block text
+        </BsTooltip>
+      </template>,
+    );
 
     assert.dom('.tooltip').exists({ count: 1 }, 'has tooltip class');
     // assert.ok(find('.tooltip').classList.contains(tooltipPositionClass('top')), 'has placement class');
@@ -67,12 +68,19 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   skip('it supports different placements', async function (assert) {
     let placements = ['top', 'left', 'bottom', 'right'];
-    this.set('placement', placements[0]);
-    await render(hbs`<BsTooltip::Element @id='tooltip-element' @placement={{this.placement}}>
-  template block text
-</BsTooltip::Element>`);
+    class State {
+      @tracked placement = placements[0];
+    }
+    const state = new State();
+    await render(
+      <template>
+        <BsTooltipElement @id='tooltip-element' @placement={{state.placement}}>
+          template block text
+        </BsTooltipElement>
+      </template>,
+    );
     placements.forEach((placement) => {
-      this.set('placement', placement);
+      state.placement = placement;
       let placementClass = tooltipPositionClass(placement);
       assert
         .dom('.tooltip')
@@ -81,30 +89,38 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it shows visible tooltip', async function (assert) {
-    await render(hbs`<BsTooltip @title='Dummy' @visible={{true}} />`);
+    await render(
+      <template><BsTooltip @title='Dummy' @visible={{true}} /></template>,
+    );
 
     assert.dom('.tooltip').exists({ count: 1 }, 'tooltip is visible');
     assert.dom('.tooltip .tooltip-inner').hasText('Dummy');
   });
 
   test('it shows visible tooltip with block content', async function (assert) {
-    await render(hbs`<BsTooltip @visible={{true}}>
-  BLOCK
-</BsTooltip>`);
+    await render(
+      <template>
+        <BsTooltip @visible={{true}}>
+          BLOCK
+        </BsTooltip>
+      </template>,
+    );
 
     assert.dom('.tooltip').exists({ count: 1 }, 'tooltip is visible');
     assert.dom('.tooltip .tooltip-inner').hasText('BLOCK');
   });
 
   test('it hides invisible tooltip', async function (assert) {
-    await render(hbs`<BsTooltip @title='Dummy' />`);
+    await render(<template><BsTooltip @title='Dummy' /></template>);
 
     assert.dom('.tooltip').doesNotExist('tooltip is not visible');
   });
 
   test('it shows and hides immediately when hovering [fade=false]', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip @title='Dummy' @fade={{false}} /></div>`,
+      <template>
+        <div id='target'><BsTooltip @title='Dummy' @fade={{false}} /></div>
+      </template>,
     );
 
     await triggerEvent('#target', 'mouseenter');
@@ -118,10 +134,12 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     'it shows and hides immediately when focusing [fade=false]',
     async function (assert) {
       await render(
-        hbs`<button type='button' class='btn' id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-  /></button>`,
+        <template>
+          <button type='button' class='btn' id='target'><BsTooltip
+              @title='Dummy'
+              @fade={{false}}
+            /></button>
+        </template>,
       );
 
       await focus('#target');
@@ -134,11 +152,13 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it shows and hides immediately when clicking [fade=false]', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @triggerEvents='click'
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @triggerEvents='click'
+          /></div>
+      </template>,
     );
 
     await click('#target');
@@ -150,11 +170,13 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it allows changing the trigger element to some arbitrary element', async function (assert) {
     await render(
-      hbs`<div id='target'></div><div><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @triggerElement='#target'
-  /></div>`,
+      <template>
+        <div id='target'></div><div><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @triggerElement='#target'
+          /></div>
+      </template>,
     );
 
     await triggerEvent('#target', 'mouseenter');
@@ -166,11 +188,13 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('trigger element can be rendered later in dom order than its tooltip', async function (assert) {
     await render(
-      hbs`<div><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @triggerElement='#target'
-  /></div><div id='target'></div>`,
+      <template>
+        <div><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @triggerElement='#target'
+          /></div><div id='target'></div>
+      </template>,
     );
 
     await triggerEvent('#target', 'mouseenter');
@@ -181,17 +205,17 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it calls onShow/onShown actions when showing tooltip by event [fade=false]', async function (assert) {
-    let showAction = sinon.spy();
-    this.set('show', showAction);
-    let shownAction = sinon.spy();
-    this.set('shown', shownAction);
+    const showAction = sinon.spy();
+    const shownAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @onShow={{this.show}}
-    @onShown={{this.shown}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @onShow={{showAction}}
+            @onShown={{shownAction}}
+          /></div>
+      </template>,
     );
     await triggerEvent('#target', 'mouseenter');
     assert.ok(showAction.calledOnce, 'show action has been called');
@@ -199,39 +223,41 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it calls onShow/onShown actions when showing tooltip programmatically [fade=false]', async function (assert) {
-    let showAction = sinon.spy();
-    this.set('show', showAction);
-    let shownAction = sinon.spy();
-    this.set('shown', shownAction);
-    this.set('visible', false);
+    class State {
+      @tracked visible = false;
+    }
+    const state = new State();
+    const showAction = sinon.spy();
+    const shownAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @visible={{this.visible}}
-    @fade={{false}}
-    @onShow={{this.show}}
-    @onShown={{this.shown}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @visible={{state.visible}}
+            @fade={{false}}
+            @onShow={{showAction}}
+            @onShown={{shownAction}}
+          /></div>
+      </template>,
     );
-    this.set('visible', true);
+    state.visible = true;
     await settled();
     assert.ok(showAction.calledOnce, 'show action has been called');
     assert.ok(shownAction.calledOnce, 'shown action has been called');
   });
 
   test('it aborts showing if onShow action returns false', async function (assert) {
-    let showAction = sinon.stub();
-    showAction.returns(false);
-    this.set('show', showAction);
-    let shownAction = sinon.spy();
-    this.set('shown', shownAction);
+    const showAction = sinon.stub().returns(false);
+    const shownAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @onShow={{this.show}}
-    @onShown={{this.shown}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @onShow={{showAction}}
+            @onShown={{shownAction}}
+          /></div>
+      </template>,
     );
     await triggerEvent('#target', 'mouseenter');
     assert.ok(showAction.calledOnce, 'show action has been called');
@@ -240,17 +266,17 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it calls onHide/onHidden actions when hiding tooltip by event [fade=false]', async function (assert) {
-    let hideAction = sinon.spy();
-    this.set('hide', hideAction);
-    let hiddenAction = sinon.spy();
-    this.set('hidden', hiddenAction);
+    const hideAction = sinon.spy();
+    const hiddenAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @onHide={{this.hide}}
-    @onHidden={{this.hidden}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @onHide={{hideAction}}
+            @onHidden={{hiddenAction}}
+          /></div>
+      </template>,
     );
     await triggerEvent('#target', 'mouseenter');
     await triggerEvent('#target', 'mouseleave');
@@ -259,39 +285,41 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it calls onHide/onHidden actions when hiding tooltip programmatically [fade=false]', async function (assert) {
-    let hideAction = sinon.spy();
-    this.set('hide', hideAction);
-    let hiddenAction = sinon.spy();
-    this.set('hidden', hiddenAction);
-    this.set('visible', true);
+    class State {
+      @tracked visible = true;
+    }
+    const state = new State();
+    const hideAction = sinon.spy();
+    const hiddenAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @visible={{this.visible}}
-    @title='Dummy'
-    @fade={{false}}
-    @onHide={{this.hide}}
-    @onHidden={{this.hidden}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @visible={{state.visible}}
+            @title='Dummy'
+            @fade={{false}}
+            @onHide={{hideAction}}
+            @onHidden={{hiddenAction}}
+          /></div>
+      </template>,
     );
-    this.set('visible', false);
+    state.visible = false;
     await settled();
     assert.ok(hideAction.calledOnce, 'hide action has been called');
     assert.ok(hiddenAction.calledOnce, 'hidden action was called');
   });
 
   test('it aborts hiding if onHide action returns false', async function (assert) {
-    let hideAction = sinon.stub();
-    hideAction.returns(false);
-    this.set('hide', hideAction);
-    let hiddenAction = sinon.spy();
-    this.set('hidden', hiddenAction);
+    const hideAction = sinon.stub().returns(false);
+    const hiddenAction = sinon.spy();
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @fade={{false}}
-    @onHide={{this.hide}}
-    @onHidden={{this.hidden}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @fade={{false}}
+            @onHide={{hideAction}}
+            @onHidden={{hiddenAction}}
+          /></div>
+      </template>,
     );
     await triggerEvent('#target', 'mouseenter');
     await triggerEvent('#target', 'mouseleave');
@@ -304,7 +332,12 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     'it keeps showing when leaving the mouse but is still focused [fade=false]',
     async function (assert) {
       await render(
-        hbs`<a href='#' id='target'><BsTooltip @title='Dummy' @fade={{false}} /></a>`,
+        <template>
+          <a href='#' id='target'><BsTooltip
+              @title='Dummy'
+              @fade={{false}}
+            /></a>
+        </template>,
       );
 
       await focus('#target');
@@ -318,15 +351,20 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   );
 
   test("Renders in wormhole's default destination if renderInPlace is not set", async function (assert) {
-    this.set('show', false);
+    class State {
+      @tracked show = false;
+    }
+    const state = new State();
     await render(
-      hbs`<div id='ember-bootstrap-wormhole'></div>{{#if this.show}}<BsTooltip
-    @title='Simple Tooltip'
-    @visible={{true}}
-    @fade={{false}}
-  />{{/if}}`,
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>{{#if state.show}}<BsTooltip
+            @title='Simple Tooltip'
+            @visible={{true}}
+            @fade={{false}}
+          />{{/if}}
+      </template>,
     );
-    this.set('show', true);
+    state.show = true;
     await settled();
 
     assert
@@ -335,15 +373,20 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('Renders in test container if renderInPlace is not set', async function (assert) {
-    this.set('show', false);
+    class State {
+      @tracked show = false;
+    }
+    const state = new State();
     await render(
-      hbs`{{#if this.show}}<BsTooltip
-    @title='Simple Tooltip'
-    @visible={{true}}
-    @fade={{false}}
-  />{{/if}}`,
+      <template>
+        {{#if state.show}}<BsTooltip
+            @title='Simple Tooltip'
+            @visible={{true}}
+            @fade={{false}}
+          />{{/if}}
+      </template>,
     );
-    this.set('show', true);
+    state.show = true;
     await settled();
 
     assert.dom('.tooltip').exists({ count: 1 }, 'Tooltip exists.');
@@ -351,18 +394,23 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('Renders in place (no wormhole) if renderInPlace is set', async function (assert) {
-    this.set('show', false);
+    class State {
+      @tracked show = false;
+    }
+    const state = new State();
     await render(
-      hbs`<div id='ember-bootstrap-wormhole'></div><div id='wrapper'>{{#if
-    this.show
-  }}<BsTooltip
-      @title='Simple Tooltip'
-      @visible={{true}}
-      @fade={{false}}
-      @renderInPlace={{true}}
-    />{{/if}}</div>`,
+      <template>
+        <div id='ember-bootstrap-wormhole'></div><div id='wrapper'>{{#if
+            state.show
+          }}<BsTooltip
+              @title='Simple Tooltip'
+              @visible={{true}}
+              @fade={{false}}
+              @renderInPlace={{true}}
+            />{{/if}}</div>
+      </template>,
     );
-    this.set('show', true);
+    state.show = true;
     await settled();
 
     assert
@@ -373,16 +421,20 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should place tooltip on top of element', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
-    await render(hbs`<div id='wrapper'>
-  <p class='margin-top'>
-    <a href='#' id='target'>
-      Hover me<BsTooltip
-        @title='very very very very very very very long tooltip'
-        @fade={{false}}
-      />
-    </a>
-  </p>
-</div>`);
+    await render(
+      <template>
+        <div id='wrapper'>
+          <p class='margin-top'>
+            <a href='#' id='target'>
+              Hover me<BsTooltip
+                @title='very very very very very very very long tooltip'
+                @fade={{false}}
+              />
+            </a>
+          </p>
+        </div>
+      </template>,
+    );
 
     setupForPositioning();
 
@@ -393,22 +445,31 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should place tooltip on top of element if already visible', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
-    await render(hbs`<div id='wrapper'>
-  {{#if this.visible}}
-    <p class='margin-top'>
-      <a href='#' id='target'>
-        Hover me<BsTooltip
-          @title='very very very very very very very long tooltip'
-          @fade={{false}}
-          @visible={{true}}
-        />
-      </a>
-    </p>
-  {{/if}}
-</div>`);
+    class State {
+      @tracked visible;
+    }
+    const state = new State();
+
+    await render(
+      <template>
+        <div id='wrapper'>
+          {{#if state.visible}}
+            <p class='margin-top'>
+              <a href='#' id='target'>
+                Hover me<BsTooltip
+                  @title='very very very very very very very long tooltip'
+                  @fade={{false}}
+                  @visible={{true}}
+                />
+              </a>
+            </p>
+          {{/if}}
+        </div>
+      </template>,
+    );
 
     setupForPositioning();
-    this.set('visible', true);
+    state.visible = true;
     await settled();
     assertPositioning(assert, '.tooltip', 6);
   });
@@ -416,29 +477,39 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should place tooltip on top of element if visible is set to true', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
-    this.set('visible', false);
-    await render(hbs`<div id='wrapper'>
-  <p class='margin-top'>
-    <a href='#' id='target'>
-      Hover me<BsTooltip
-        @title='very very very very very very very long tooltip'
-        @fade={{false}}
-        @visible={{this.visible}}
-      />
-    </a>
-  </p>
-</div>`);
+    class State {
+      @tracked visible = false;
+    }
+    const state = new State();
+
+    await render(
+      <template>
+        <div id='wrapper'>
+          <p class='margin-top'>
+            <a href='#' id='target'>
+              Hover me<BsTooltip
+                @title='very very very very very very very long tooltip'
+                @fade={{false}}
+                @visible={{state.visible}}
+              />
+            </a>
+          </p>
+        </div>
+      </template>,
+    );
 
     setupForPositioning();
 
-    this.set('visible', true);
+    state.visible = true;
     await settled();
     assertPositioning(assert, '.tooltip', 6);
   });
 
   test("should show tooltip if leave event hasn't occurred before delay expires", async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>`,
+      <template>
+        <div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>
+      </template>,
     );
 
     triggerEvent('#target', 'mouseenter');
@@ -458,7 +529,9 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('should not show tooltip if leave event occurs before delay expires', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>`,
+      <template>
+        <div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>
+      </template>,
     );
 
     triggerEvent('#target', 'mouseenter');
@@ -479,11 +552,13 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('should not hide tooltip if leave event occurs and enter event occurs within the hide delay', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    @delayShow={{0}}
-    @delayHide={{150}}
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            @delayShow={{0}}
+            @delayHide={{150}}
+          /></div>
+      </template>,
     );
     triggerEvent('#target', 'mouseenter');
 
@@ -506,7 +581,9 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('should not show tooltip if leave event occurs before delay expires', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>`,
+      <template>
+        <div id='target'><BsTooltip @title='Dummy' @delay={{150}} /></div>
+      </template>,
     );
     triggerEvent('#target', 'mouseenter');
 
@@ -528,18 +605,22 @@ module('Integration | Component | bs-tooltip', function (hooks) {
     this.insertCSSRule('.margin-top { margin-top: 200px; }');
 
     let expectedArrowPosition = 94;
-    await render(hbs`<div id='ember-bootstrap-wormhole'></div>
-<div id='wrapper'>
-  <p class='margin-top'>
-    <button type='button' class='btn' id='target'>
-      Click me<BsTooltip
-        @placement='top'
-        @title='very very very very very very very long tooltip'
-        @fade={{false}}
-      />
-    </button>
-  </p>
-</div>`);
+    await render(
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>
+        <div id='wrapper'>
+          <p class='margin-top'>
+            <button type='button' class='btn' id='target'>
+              Click me<BsTooltip
+                @placement='top'
+                @title='very very very very very very very long tooltip'
+                @fade={{false}}
+              />
+            </button>
+          </p>
+        </div>
+      </template>,
+    );
 
     setupForPositioning();
 
@@ -562,20 +643,24 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
     let expectedArrowPosition = 144;
 
-    await render(hbs`<div id='ember-bootstrap-wormhole'></div>
-<div id='wrapper'>
-  <p class='margin-top'>
-    <button type='button' id='target'>
-      Click me<BsTooltip
-        @autoPlacement={{true}}
-        @viewportSelector='#wrapper'
-        @placement='top'
-        @title='very very very very very very very long tooltip'
-        @fade={{false}}
-      />
-    </button>
-  </p>
-</div>`);
+    await render(
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>
+        <div id='wrapper'>
+          <p class='margin-top'>
+            <button type='button' id='target'>
+              Click me<BsTooltip
+                @autoPlacement={{true}}
+                @viewportSelector='#wrapper'
+                @placement='top'
+                @title='very very very very very very very long tooltip'
+                @fade={{false}}
+              />
+            </button>
+          </p>
+        </div>
+      </template>,
+    );
 
     setupForPositioning('right');
 
@@ -611,19 +696,23 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   test('should adjust placement if not fitting in viewport', async function (assert) {
     this.insertCSSRule('.margin-top { margin-top: 300px; }');
 
-    await render(hbs`<div id='ember-bootstrap-wormhole'></div>
-<div id='wrapper'>
-  <p class='margin-top'>
-    <button type='button' class='btn' id='target'>
-      Click me<BsTooltip
-        @placement='bottom'
-        @autoPlacement={{true}}
-        @title='very very very very very very very long tooltip'
-        @fade={{false}}
-      />
-    </button>
-  </p>
-</div>`);
+    await render(
+      <template>
+        <div id='ember-bootstrap-wormhole'></div>
+        <div id='wrapper'>
+          <p class='margin-top'>
+            <button type='button' class='btn' id='target'>
+              Click me<BsTooltip
+                @placement='bottom'
+                @autoPlacement={{true}}
+                @title='very very very very very very very long tooltip'
+                @fade={{false}}
+              />
+            </button>
+          </p>
+        </div>
+      </template>,
+    );
 
     setupForPositioning('right');
     await click('#target');
@@ -634,20 +723,22 @@ module('Integration | Component | bs-tooltip', function (hooks) {
   });
 
   test('it yields close action', async function (assert) {
-    let hideAction = sinon.spy();
-    this.set('hide', hideAction);
-    let hiddenAction = sinon.spy();
-    this.set('hidden', hiddenAction);
-    await render(hbs`<div id='target'>
-  <BsTooltip
-    @visible={{true}}
-    @onHide={{action this.hide}}
-    @onHidden={{action this.hidden}}
-    as |tt|
-  >
-    <div id='hide' {{action tt.close}} role='button'>Hide</div>
-  </BsTooltip>
-</div>`);
+    const hideAction = sinon.spy();
+    const hiddenAction = sinon.spy();
+    await render(
+      <template>
+        <div id='target'>
+          <BsTooltip
+            @visible={{true}}
+            @onHide={{hideAction}}
+            @onHidden={{hiddenAction}}
+            as |tt|
+          >
+            <div id='hide' {{on 'click' tt.close}} role='button'>Hide</div>
+          </BsTooltip>
+        </div>
+      </template>,
+    );
     await click('#hide');
     assert.ok(hideAction.calledOnce, 'hide action has been called');
     assert.ok(hiddenAction.calledOnce, 'hidden action was called');
@@ -656,12 +747,14 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   test('it passes all HTML attribute', async function (assert) {
     await render(
-      hbs`<div id='target'><BsTooltip
-    @title='Dummy'
-    class='wide'
-    data-test
-    role='foo'
-  /></div>`,
+      <template>
+        <div id='target'><BsTooltip
+            @title='Dummy'
+            class='wide'
+            data-test
+            role='foo'
+          /></div>
+      </template>,
     );
     await triggerEvent('#target', 'mouseenter');
     assert.dom('.tooltip').hasClass('wide');
@@ -671,24 +764,33 @@ module('Integration | Component | bs-tooltip', function (hooks) {
 
   // The timing of test helpers seems to have changed, which makes this test fail
   skip('can be shown and disposed in same loop', async function (assert) {
-    this.set('show', true);
+    class State {
+      @tracked show = true;
+    }
+    const state = new State();
     await render(
-      hbs`{{#if this.show}}<div id='target'><BsTooltip
-      @title='Dummy'
-      class='wide'
-    /></div>{{/if}}`,
+      <template>
+        {{#if state.show}}<div id='target'><BsTooltip
+              @title='Dummy'
+              class='wide'
+            /></div>{{/if}}
+      </template>,
     );
     triggerEvent('#target', 'mouseenter');
-    this.set('show', false);
+    state.show = false;
     await settled();
     assert.dom('.tooltip').doesNotExist();
   });
 
   test('it passes accessibility checks', async function (assert) {
-    await render(hbs`<button type='button'>
-  Test
-  <BsTooltip @title='Dummy' @visible={{true}} />
-</button>`);
+    await render(
+      <template>
+        <button type='button'>
+          Test
+          <BsTooltip @title='Dummy' @visible={{true}} />
+        </button>
+      </template>,
+    );
 
     await a11yAudit();
     assert.ok(true, 'A11y audit passed');


### PR DESCRIPTION
These remaining ones did not have obvious groups, so I put them together to not create a large dump of PR's.
I can split them up if preferred.