### PR TITLE
Widen support for ember-render-helpers to v1

### DIFF
--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -57,7 +57,7 @@
     "ember-on-helper": "^0.1.0",
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",
-    "ember-render-helpers": "^1.0.0",
+    "ember-render-helpers": "^0.2.0 || ^1.0.0",
     "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "findup-sync": "^5.0.0",
     "resolve": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ importers:
         specifier: ^4.0.0 || ^5.0.0
         version: 5.0.7(@babel/core@7.24.9)(@glint/template@1.4.0)(ember-source@5.10.1)(webpack@5.94.0)
       ember-render-helpers:
-        specifier: ^1.0.0
+        specifier: ^0.2.0 || ^1.0.0
         version: 1.0.2(@babel/core@7.24.9)
       ember-source:
         specifier: '>=4.8.0'
@@ -9937,7 +9937,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -74,6 +74,15 @@ module.exports = async function () {
           },
         },
       },
+      {
+        name: 'ember-render-helpers-v0.2',
+        npm: {
+          devDependencies: {
+            bootstrap: bootstrapVersion,
+            'ember-render-helpers': '^0.2.0',
+          },
+        },
+      },
       embroiderSafe({
         npm: {
           devDependencies: {


### PR DESCRIPTION
Support for ember-render-helpers@^1.0.0 has been added in #2141 already. But accidentally support for ember-render-helpers@^0.2.0 has been dropped.  We don't want that as it would make upgrading more complex for consumers. And may be considered a breaking change.

The change has not been released yet. So it is safe to just fix it before releasing.

Adding a changelog entry because there isn't one for #2141 yet.

I decided adding an additional ember-try scenario for ember-render-helpers@^0.2.0 because some code were changed on the upgrade as well.