### PR TITLE
Fix compatibility with ember-render-helpers v0.2

### DIFF
--- a/ember-bootstrap/package.json
+++ b/ember-bootstrap/package.json
@@ -57,7 +57,7 @@
     "ember-on-helper": "^0.1.0",
     "ember-popper-modifier": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "ember-ref-bucket": "^4.0.0 || ^5.0.0",
-    "ember-render-helpers": "^0.2.0 || ^1.0.0",
+    "ember-render-helpers": "^0.2.1 || ^1.0.0",
     "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "findup-sync": "^5.0.0",
     "resolve": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,7 +285,7 @@ importers:
         specifier: ^4.0.0 || ^5.0.0
         version: 5.0.7(@babel/core@7.24.9)(@glint/template@1.4.0)(ember-source@5.10.1)(webpack@5.94.0)
       ember-render-helpers:
-        specifier: ^0.2.0 || ^1.0.0
+        specifier: ^0.2.1 || ^1.0.0
         version: 1.0.2(@babel/core@7.24.9)
       ember-source:
         specifier: '>=4.8.0'

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -74,15 +74,6 @@ module.exports = async function () {
           },
         },
       },
-      {
-        name: 'ember-render-helpers-v0.2',
-        npm: {
-          devDependencies: {
-            bootstrap: bootstrapVersion,
-            'ember-render-helpers': '^0.2.0',
-          },
-        },
-      },
       embroiderSafe({
         npm: {
           devDependencies: {


### PR DESCRIPTION
#2156 should have restored compatibility with ember-render-helpers@^0.2.0 but it hasn't. The test had a bug and therefore leading to a false sense of security. The helpers were renamed in the v1.0 release _and_ the new names weren't available in v0.2.0.

This PR requires [ember-render-helpers v0.2.1](https://github.com/buschtoens/ember-render-helpers/releases/tag/v0.2.1) which backports the new helper names.

It removes the test as it was not working as expected anyways. See https://github.com/ember-bootstrap/ember-bootstrap/pull/2157#issuecomment-2417696426 and https://github.com/ember-cli/ember-try/issues/970 for context.