### PR TITLE
remove unused arguments introduced by mistake

### DIFF
--- a/ember-bootstrap/addon/components/bs-dropdown.hbs
+++ b/ember-bootstrap/addon/components/bs-dropdown.hbs
@@ -5,7 +5,6 @@
       {{if this.inNav "nav-item"}}
       {{if this.isOpen "show"}}"
     ...attributes
-    {{did-update this.updateIsOpen @open}}
   >
     {{yield
       (hash

--- a/ember-bootstrap/addon/components/bs-dropdown.js
+++ b/ember-bootstrap/addon/components/bs-dropdown.js
@@ -196,7 +196,7 @@ export default class Dropdown extends Component {
    * @type boolean
    * @private
    */
-  @tracked isOpen = this.args.isOpen ?? false;
+  @tracked isOpen = false;
 
   /**
    * By default, clicking on an open dropdown menu will close it. Set this property to false for the menu to stay open.
@@ -430,11 +430,6 @@ export default class Dropdown extends Component {
     );
 
     this[`${type}Element`] = null;
-  }
-
-  @action
-  updateIsOpen(open) {
-    this.isOpen = open;
   }
 
   /**

--- a/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.hbs
@@ -9,7 +9,6 @@
       {{popper-tooltip @toggleElement this.popperOptions}}
       {{did-insert @registerChildElement "menu"}}
       {{will-destroy @unregisterChildElement "menu"}}
-      {{did-update this.updateIsOpen @open}}
       {{create-ref "menuElement"}}
     >
       {{yield
@@ -31,7 +30,6 @@
         {{popper-tooltip @toggleElement this.popperOptions}}
         {{did-insert @registerChildElement "menu"}}
         {{will-destroy @unregisterChildElement "menu"}}
-        {{did-update this.updateIsOpen @open}}
         {{create-ref "menuElement"}}
       >
         {{yield

--- a/ember-bootstrap/addon/components/bs-dropdown/menu.js
+++ b/ember-bootstrap/addon/components/bs-dropdown/menu.js
@@ -1,6 +1,5 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { next } from '@ember/runloop';
 import { getDestinationElement } from 'ember-bootstrap/utils/dom';
 import { ref } from 'ember-ref-bucket';
 import { tracked } from '@glimmer/tracking';
@@ -100,18 +99,6 @@ export default class DropdownMenu extends Component {
 
   @tracked
   isOpen = this.args.isOpen;
-
-  @action
-  updateIsOpen(value) {
-    // delay removing the menu from DOM to allow (delegated Ember) event to fire for the menu's children
-    // Fixes https://github.com/kaliber5/ember-bootstrap/issues/660
-    next(() => {
-      if (this.isDestroying || this.isDestroyed) {
-        return;
-      }
-      this.isOpen = value;
-    });
-  }
 
   flip = true;
 


### PR DESCRIPTION
I noticed some arguments, which are either documented as internal or not documented at all, when refactoring `<BsDropdown>` and related components to TypeScript. Those are not used internally. They seem to be introduced by mistake when refactoring to `@glimmer/component`. I think we can drop them.