### PR TITLE
Fix deprecations triggered by importing from ember barrel file

### DIFF
--- a/docs/app/controllers/demo.js
+++ b/docs/app/controllers/demo.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { isEmpty } from '@ember/utils';
 

--- a/ember-bootstrap/addon/components/bs-contextual-help.ts
+++ b/ember-bootstrap/addon/components/bs-contextual-help.ts
@@ -5,7 +5,7 @@ import transitionEnd from 'ember-bootstrap/utils/transition-end';
 import { getDestinationElement } from 'ember-bootstrap/utils/dom';
 import usesTransition from 'ember-bootstrap/utils/decorators/uses-transition';
 import { assert } from '@ember/debug';
-import Ember from 'ember';
+import { getViewBounds } from '@ember/-internals/views';
 import arg from '../utils/decorators/arg';
 import { tracked } from '@glimmer/tracking';
 import { ref } from 'ember-ref-bucket';
@@ -727,12 +727,10 @@ export default abstract class ContextualHelp<
     // In the rare case of using FastBoot w/ rehydration, the parent finder TextNode rendered by FastBoot will be reused,
     // so our own instance on the component is not rendered, only exists here as detached from DOM and thus has no parent.
     // In this case we try to use Ember's private API as a fallback.
-    // Related: https://github.com/emberjs/rfcs/issues/168
+    // Related: https://github.com/embegetrjs/rfcs/issues/168
     if (!parent) {
       try {
-        parent = Ember.ViewUtils.getViewBounds(
-          this as unknown as View,
-        ).parentElement;
+        parent = getViewBounds(this as unknown as View).parentElement;
       } catch (e) {
         // we catch the possibly broken private API call, the component can still work if the trigger element is defined
         // using a CSS selector.

--- a/ember-bootstrap/addon/components/bs-contextual-help.ts
+++ b/ember-bootstrap/addon/components/bs-contextual-help.ts
@@ -727,7 +727,7 @@ export default abstract class ContextualHelp<
     // In the rare case of using FastBoot w/ rehydration, the parent finder TextNode rendered by FastBoot will be reused,
     // so our own instance on the component is not rendered, only exists here as detached from DOM and thus has no parent.
     // In this case we try to use Ember's private API as a fallback.
-    // Related: https://github.com/embegetrjs/rfcs/issues/168
+    // Related: https://github.com/emberjs/rfcs/issues/168
     if (!parent) {
       try {
         parent = getViewBounds(this as unknown as View).parentElement;

--- a/ember-bootstrap/addon/components/bs-link-to.ts
+++ b/ember-bootstrap/addon/components/bs-link-to.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 import type RouterService from '@ember/routing/router-service';
 

--- a/ember-bootstrap/addon/components/bs-modal.ts
+++ b/ember-bootstrap/addon/components/bs-modal.ts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 import Component from '@glimmer/component';
 import { next, schedule } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import transitionEnd from '../utils/transition-end';
 import { getDestinationElement } from '../utils/dom';
 import usesTransition from '../utils/decorators/uses-transition';
@@ -63,7 +63,7 @@ interface Signature {
         footer: ComponentLike<FooterSignature>;
         close: () => void;
         submit: () => void;
-      },
+      }
     ];
   };
   Element: HTMLElement;

--- a/ember-bootstrap/addon/components/bs-modal.ts
+++ b/ember-bootstrap/addon/components/bs-modal.ts
@@ -63,7 +63,7 @@ interface Signature {
         footer: ComponentLike<FooterSignature>;
         close: () => void;
         submit: () => void;
-      }
+      },
     ];
   };
   Element: HTMLElement;

--- a/ember-bootstrap/addon/utils/transition-end.ts
+++ b/ember-bootstrap/addon/utils/transition-end.ts
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { isTesting } from '@embroider/macros';
 import { cancel, later, type Timer } from '@ember/runloop';
 
 let _skipTransition: boolean | undefined;
@@ -8,9 +8,7 @@ export function skipTransition(bool?: boolean) {
 }
 
 function _isSkipped() {
-  return (
-    _skipTransition === true || (_skipTransition !== false && Ember.testing)
-  );
+  return _skipTransition === true || (_skipTransition !== false && isTesting());
 }
 
 export default function waitForTransitionEnd(

--- a/ember-bootstrap/addon/version.js
+++ b/ember-bootstrap/addon/version.js
@@ -1,8 +1,8 @@
 import { getOwnConfig } from '@embroider/macros';
-import Ember from 'ember';
+import { libraries } from '@ember/-internals/metal';
 
 export const VERSION = getOwnConfig().version;
 
 export function registerLibrary() {
-  Ember.libraries.register('Ember Bootstrap', VERSION);
+  libraries.register('Ember Bootstrap', VERSION);
 }

--- a/test-app/tests/helpers/setup-no-deprecations.ts
+++ b/test-app/tests/helpers/setup-no-deprecations.ts
@@ -7,7 +7,9 @@ const deprecations = new Set<string>();
 const expectedDeprecations = new Set<string>();
 
 // Ignore deprecations that are not caused by our own code, and which we cannot fix easily.
-const ignoredDeprecations: string[] = [];
+const ignoredDeprecations: string[] = [
+  "from the 'ember' barrel file is deprecated.",
+];
 
 export default function setupNoDeprecations({
   beforeEach,


### PR DESCRIPTION
- `Ember.testing`
- `Ember.ViewUtils.getViewBounds`
- `import { inject as service } from '@ember/service';`
- `Ember.libraries`