### PR TITLE
Disable modal animation tests in Safari

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,8 +457,8 @@ importers:
         specifier: 3.0.9
         version: 3.0.9
       '@types/qunit':
-        specifier: 2.19.10
-        version: 2.19.10
+        specifier: 2.19.13
+        version: 2.19.13
       '@types/rsvp':
         specifier: 4.0.9
         version: 4.0.9
@@ -3397,8 +3397,8 @@ packages:
     resolution: {integrity: sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==}
     dev: true
 
-  /@types/qunit@2.19.10:
-    resolution: {integrity: sha512-gVB+rxvxmbyPFWa6yjjKgcumWal3hyqoTXI0Oil161uWfo1OCzWZ/rnEumsx+6uVgrwPrCrhpQbLkzfildkSbg==}
+  /@types/qunit@2.19.13:
+    resolution: {integrity: sha512-N4xp3v4s7f0jb2Oij6+6xw5QhH7/IgHCoGIFLCWtbEWoPkGYp8Te4mIwIP21qaurr6ed5JiPMiy2/ZoiGPkLIw==}
     dev: true
 
   /@types/range-parser@1.2.7:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -35,7 +35,7 @@
     "@glint/template": "1.5.2",
     "@popperjs/core": "2.11.8",
     "@tsconfig/ember": "3.0.9",
-    "@types/qunit": "2.19.10",
+    "@types/qunit": "2.19.13",
     "@types/rsvp": "4.0.9",
     "@types/sinon": "17.0.4",
     "@typescript-eslint/eslint-plugin": "7.18.0",

--- a/test-app/tests/helpers/bootstrap.ts
+++ b/test-app/tests/helpers/bootstrap.ts
@@ -6,7 +6,7 @@ const currentBootstrapVersion = config.bootstrapVersion;
 
 function test<TC extends CustomTestContext>(
   name: string,
-  callback: (this: TC, assert: CustomAssert) => void | Promise<unknown>,
+  callback: (this: TC, assert: CustomAssert) => void | Promise<void>,
 ) {
   qunitTest(name, callback);
 }

--- a/test-app/tests/integration/components/bs-modal-test.gts
+++ b/test-app/tests/integration/components/bs-modal-test.gts
@@ -383,86 +383,90 @@ module('Integration | Component | bs-modal', function (hooks) {
   );
 
   // TODO #2197: Fix modal animation tests on Safari
-  module.if('it animates opening and closing the modal', !isSafari, function () {
-    hooks.before(function () {
-      skipTransition(false);
-    });
-
-    hooks.after(function () {
-      skipTransition(undefined);
-    });
-
-    test('it animates opening the modal', async function (assert) {
-      class State {
-        @tracked open = false;
-      }
-
-      const state = new State();
-      await render(
-        <template>
-          <BsModal @open={{state.open}}>Hello world!</BsModal>
-        </template>,
-      );
-
-      state.open = true;
-      await waitFor('.modal.show');
-      assert.dom('.modal').hasStyle({ display: 'block' });
-
-      await waitUntil(() => {
-        return find('.modal')!.getAnimations().length > 0;
+  module.if(
+    'it animates opening and closing the modal',
+    !isSafari,
+    function () {
+      hooks.before(function () {
+        skipTransition(false);
       });
-      assert.ok(
-        find('.modal')!
-          .getAnimations()
-          .find(
-            (animation) =>
-              (animation as CSSTransition).transitionProperty === 'opacity',
-          ),
-        'modal opening is animated',
-      );
-    });
 
-    test('it animates closing the modal', async function (assert) {
-      await render(
-        <template>
-          <BsModal as |modal|>
-            <button {{on 'click' modal.close}} type='button'>close</button>
-          </BsModal>
-        </template>,
-      );
-
-      // wait until modal is shown and opening transition is finished
-      await waitFor('.modal.show');
-      await Promise.all(
-        find('.modal')!
-          .getAnimations()
-          .map((animation) => animation.finished),
-      );
-
-      // close modal
-      click('button');
-      await waitUntil(() => {
-        return !find('.modal')!.classList.contains(visibilityClass());
+      hooks.after(function () {
+        skipTransition(undefined);
       });
-      assert.dom('.modal').hasStyle({ display: 'block' });
 
-      await waitUntil(() => {
-        return find('.modal')!.getAnimations().length > 0;
+      test('it animates opening the modal', async function (assert) {
+        class State {
+          @tracked open = false;
+        }
+
+        const state = new State();
+        await render(
+          <template>
+            <BsModal @open={{state.open}}>Hello world!</BsModal>
+          </template>,
+        );
+
+        state.open = true;
+        await waitFor('.modal.show');
+        assert.dom('.modal').hasStyle({ display: 'block' });
+
+        await waitUntil(() => {
+          return find('.modal')!.getAnimations().length > 0;
+        });
+        assert.ok(
+          find('.modal')!
+            .getAnimations()
+            .find(
+              (animation) =>
+                (animation as CSSTransition).transitionProperty === 'opacity',
+            ),
+          'modal opening is animated',
+        );
       });
-      assert.ok(
-        find('.modal')!
-          .getAnimations()
-          .find(
-            (animation) =>
-              (animation as CSSTransition).transitionProperty === 'opacity',
-          ),
-        'modal closing is animated',
-      );
 
-      await settled();
-      assert.dom('.modal').doesNotExist();
-    });
-  });
+      test('it animates closing the modal', async function (assert) {
+        await render(
+          <template>
+            <BsModal as |modal|>
+              <button {{on 'click' modal.close}} type='button'>close</button>
+            </BsModal>
+          </template>,
+        );
+
+        // wait until modal is shown and opening transition is finished
+        await waitFor('.modal.show');
+        await Promise.all(
+          find('.modal')!
+            .getAnimations()
+            .map((animation) => animation.finished),
+        );
+
+        // close modal
+        click('button');
+        await waitUntil(() => {
+          return !find('.modal')!.classList.contains(visibilityClass());
+        });
+        assert.dom('.modal').hasStyle({ display: 'block' });
+
+        await waitUntil(() => {
+          return find('.modal')!.getAnimations().length > 0;
+        });
+        assert.ok(
+          find('.modal')!
+            .getAnimations()
+            .find(
+              (animation) =>
+                (animation as CSSTransition).transitionProperty === 'opacity',
+            ),
+          'modal closing is animated',
+        );
+
+        await settled();
+        assert.dom('.modal').doesNotExist();
+      });
+    },
+  );
 
   test('Modal shows appropriate size respective to @size argument', async function (assert) {
     class State {

--- a/test-app/tests/integration/components/bs-modal-test.gts
+++ b/test-app/tests/integration/components/bs-modal-test.gts
@@ -382,6 +382,7 @@ module('Integration | Component | bs-modal', function (hooks) {
     },
   );
 
+  // TODO #2197: Fix modal animation tests on Safari
   if (!isSafari) {
     module('it animates opening and closing the modal', function () {
       hooks.before(function () {

--- a/test-app/tests/integration/components/bs-modal-test.gts
+++ b/test-app/tests/integration/components/bs-modal-test.gts
@@ -383,88 +383,86 @@ module('Integration | Component | bs-modal', function (hooks) {
   );
 
   // TODO #2197: Fix modal animation tests on Safari
-  if (!isSafari) {
-    module('it animates opening and closing the modal', function () {
-      hooks.before(function () {
-        skipTransition(false);
-      });
-
-      hooks.after(function () {
-        skipTransition(undefined);
-      });
-
-      test('it animates opening the modal', async function (assert) {
-        class State {
-          @tracked open = false;
-        }
-
-        const state = new State();
-        await render(
-          <template>
-            <BsModal @open={{state.open}}>Hello world!</BsModal>
-          </template>,
-        );
-
-        state.open = true;
-        await waitFor('.modal.show');
-        assert.dom('.modal').hasStyle({ display: 'block' });
-
-        await waitUntil(() => {
-          return find('.modal')!.getAnimations().length > 0;
-        });
-        assert.ok(
-          find('.modal')!
-            .getAnimations()
-            .find(
-              (animation) =>
-                (animation as CSSTransition).transitionProperty === 'opacity',
-            ),
-          'modal opening is animated',
-        );
-      });
-
-      test('it animates closing the modal', async function (assert) {
-        await render(
-          <template>
-            <BsModal as |modal|>
-              <button {{on 'click' modal.close}} type='button'>close</button>
-            </BsModal>
-          </template>,
-        );
-
-        // wait until modal is shown and opening transition is finished
-        await waitFor('.modal.show');
-        await Promise.all(
-          find('.modal')!
-            .getAnimations()
-            .map((animation) => animation.finished),
-        );
-
-        // close modal
-        click('button');
-        await waitUntil(() => {
-          return !find('.modal')!.classList.contains(visibilityClass());
-        });
-        assert.dom('.modal').hasStyle({ display: 'block' });
-
-        await waitUntil(() => {
-          return find('.modal')!.getAnimations().length > 0;
-        });
-        assert.ok(
-          find('.modal')!
-            .getAnimations()
-            .find(
-              (animation) =>
-                (animation as CSSTransition).transitionProperty === 'opacity',
-            ),
-          'modal closing is animated',
-        );
-
-        await settled();
-        assert.dom('.modal').doesNotExist();
-      });
+  module.if('it animates opening and closing the modal', !isSafari, function () {
+    hooks.before(function () {
+      skipTransition(false);
     });
-  }
+
+    hooks.after(function () {
+      skipTransition(undefined);
+    });
+
+    test('it animates opening the modal', async function (assert) {
+      class State {
+        @tracked open = false;
+      }
+
+      const state = new State();
+      await render(
+        <template>
+          <BsModal @open={{state.open}}>Hello world!</BsModal>
+        </template>,
+      );
+
+      state.open = true;
+      await waitFor('.modal.show');
+      assert.dom('.modal').hasStyle({ display: 'block' });
+
+      await waitUntil(() => {
+        return find('.modal')!.getAnimations().length > 0;
+      });
+      assert.ok(
+        find('.modal')!
+          .getAnimations()
+          .find(
+            (animation) =>
+              (animation as CSSTransition).transitionProperty === 'opacity',
+          ),
+        'modal opening is animated',
+      );
+    });
+
+    test('it animates closing the modal', async function (assert) {
+      await render(
+        <template>
+          <BsModal as |modal|>
+            <button {{on 'click' modal.close}} type='button'>close</button>
+          </BsModal>
+        </template>,
+      );
+
+      // wait until modal is shown and opening transition is finished
+      await waitFor('.modal.show');
+      await Promise.all(
+        find('.modal')!
+          .getAnimations()
+          .map((animation) => animation.finished),
+      );
+
+      // close modal
+      click('button');
+      await waitUntil(() => {
+        return !find('.modal')!.classList.contains(visibilityClass());
+      });
+      assert.dom('.modal').hasStyle({ display: 'block' });
+
+      await waitUntil(() => {
+        return find('.modal')!.getAnimations().length > 0;
+      });
+      assert.ok(
+        find('.modal')!
+          .getAnimations()
+          .find(
+            (animation) =>
+              (animation as CSSTransition).transitionProperty === 'opacity',
+          ),
+        'modal closing is animated',
+      );
+
+      await settled();
+      assert.dom('.modal').doesNotExist();
+    });
+  });
 
   test('Modal shows appropriate size respective to @size argument', async function (assert) {
     class State {

--- a/test-app/tests/integration/components/bs-modal-test.gts
+++ b/test-app/tests/integration/components/bs-modal-test.gts
@@ -26,7 +26,7 @@ import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-const isSafari = !!(window as any).safari;
+const isSafari = !!(window as unknown as { safari?: object }).safari;
 
 module('Integration | Component | bs-modal', function (hooks) {
   setupRenderingTest(hooks);
@@ -399,9 +399,9 @@ module('Integration | Component | bs-modal', function (hooks) {
 
         const state = new State();
         await render(
-        <template>
-          <BsModal @open={{state.open}}>Hello world!</BsModal>
-        </template>,
+          <template>
+            <BsModal @open={{state.open}}>Hello world!</BsModal>
+          </template>,
         );
 
         state.open = true;
@@ -424,11 +424,11 @@ module('Integration | Component | bs-modal', function (hooks) {
 
       test('it animates closing the modal', async function (assert) {
         await render(
-        <template>
-          <BsModal as |modal|>
-            <button {{on 'click' modal.close}} type='button'>close</button>
-          </BsModal>
-        </template>,
+          <template>
+            <BsModal as |modal|>
+              <button {{on 'click' modal.close}} type='button'>close</button>
+            </BsModal>
+          </template>,
         );
 
         // wait until modal is shown and opening transition is finished


### PR DESCRIPTION
I do not have a Mac, and Epiphany (a Webkit browser) does not result in the same test failures.

For now we can opt to disable these tests when running in Safari.

I have opened #2197 to address this